### PR TITLE
大图片时 drawInRect: 容易引起OOM

### DIFF
--- a/PhotoBrowser/ZLEditViewController.m
+++ b/PhotoBrowser/ZLEditViewController.m
@@ -464,12 +464,22 @@
 
 - (UIImage *)scaleImage:(UIImage *)image toSize:(CGSize)size
 {
-    UIGraphicsBeginImageContext(size);
-    [image drawInRect:CGRectMake(0, 0, size.width, size.height)];
-    UIImage *newImage=UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return  newImage;
+    NSData *data = UIImageJPEGRepresentation(image, 1.0);
+    return [self scaledlmageWithData:data withSize:size scale:1.0 orientation:image.imageOrientation];
 }
+
+- (UIImage *)scaledlmageWithData:(NSData *)data withSize:(CGSize)size scale:(CGFloat)scale orientation:(UIImageOrientation)orientation {
+    CGFloat maxPixelSize = MAX(size.width, size.height);
+    CGImageSourceRef sourceRef = CGImageSourceCreateWithData((__bridge CFDataRef)data, nil);
+    NSDictionary *options = @{(__bridge id)kCGImageSourceCreateThumbnailFromImageAlways:(__bridge id)kCFBooleanTrue,
+                              (__bridge id)kCGImageSourceThumbnailMaxPixelSize:[NSNumber numberWithFloat:maxPixelSize]};
+    CGImageRef imageRef = CGImageSourceCreateThumbnailAtIndex(sourceRef, 0, (__bridge CFDictionaryRef)options);
+    UIImage *resultlmage = [UIImage imageWithCGImage:imageRef scale:scale orientation:orientation];
+    CGImageRelease(imageRef);
+    CFRelease(sourceRef);
+    return resultlmage;
+}
+
 
 - (void)setCropMenu
 {


### PR DESCRIPTION
[UIImage drawInRect:]在绘制时，先解码图片，再生成原始分辨率大小的bitmap，这是很耗内存的。解决方法是使用更低层的ImageIO接口，避免中间bitmap产生。🙂
参考 http://wetest.qq.com/lab/view/367.html 