### PR TITLE
fix: crash when showing actionsheet on iPad

### DIFF
--- a/PhotoBrowser/ZLShowBigImgViewController.m
+++ b/PhotoBrowser/ZLShowBigImgViewController.m
@@ -474,6 +474,13 @@
     UIAlertAction *cancel = [UIAlertAction actionWithTitle:GetLocalLanguageTextValue(ZLPhotoBrowserCancelText) style:UIAlertActionStyleCancel handler:nil];
     [alert addAction:save];
     [alert addAction:cancel];
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)  {
+        alert.popoverPresentationController.sourceView = self.view;
+        alert.popoverPresentationController.sourceRect = CGRectMake(CGRectGetMidX(self.view.frame),
+                                                                    CGRectGetMidY(self.view.frame),
+                                                                    2, 2);
+        alert.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
+    }
     [self showDetailViewController:alert sender:nil];
 }
 


### PR DESCRIPTION
`UIAlertControllerStyleActionSheet` 类型的 `UIAlertController` 在 iPad 上需要做特殊处理，否则会导致 crash