### PR TITLE
bug fix: out of bounds crash if error happens

### DIFF
--- a/Sources/General/ZLPhotoPreviewSheet.swift
+++ b/Sources/General/ZLPhotoPreviewSheet.swift
@@ -537,8 +537,8 @@ public class ZLPhotoPreviewSheet: UIView {
                     assets[i] = asset ?? m.asset
                     zl_debugPrint("ZLPhotoBrowser: suc request \(i)")
                 } else {
-                    errorAssets[i] = m.asset
-                    errorIndexs[i] = i
+                    errorAssets.append(m.asset)
+                    errorIndexs.append(i)
                     zl_debugPrint("ZLPhotoBrowser: failed request \(i)")
                 }
                 


### PR DESCRIPTION
if  images is from icloud and `isOriginal = true` , but icloud account is not avaliable. like sign outed
a crash happens