### PR TITLE
Feat:公开某些逻辑方法的权限

### DIFF
--- a/Sources/General/ZLAlbumListModel.swift
+++ b/Sources/General/ZLAlbumListModel.swift
@@ -27,35 +27,35 @@
 import UIKit
 import Photos
 
-class ZLAlbumListModel: NSObject {
+public class ZLAlbumListModel: NSObject {
 
-    let title: String
+    public let title: String
     
-    var count: Int {
+    public var count: Int {
         return result.count
     }
     
-    var result: PHFetchResult<PHAsset>
+    public var result: PHFetchResult<PHAsset>
     
-    let collection: PHAssetCollection
+    public let collection: PHAssetCollection
     
-    let option: PHFetchOptions
+    public let option: PHFetchOptions
     
-    let isCameraRoll: Bool
+    public let isCameraRoll: Bool
     
-    var headImageAsset: PHAsset? {
+    public var headImageAsset: PHAsset? {
         return result.lastObject
     }
     
-    var models: [ZLPhotoModel] = []
+    public var models: [ZLPhotoModel] = []
     
     // 暂未用到
-    var selectedModels: [ZLPhotoModel] = []
+    private var selectedModels: [ZLPhotoModel] = []
     
     // 暂未用到
-    var selectedCount: Int = 0
+    private var selectedCount: Int = 0
     
-    init(title: String, result: PHFetchResult<PHAsset>, collection: PHAssetCollection, option: PHFetchOptions, isCameraRoll: Bool) {
+    public init(title: String, result: PHFetchResult<PHAsset>, collection: PHAssetCollection, option: PHFetchOptions, isCameraRoll: Bool) {
         self.title = title
         self.result = result
         self.collection = collection
@@ -63,7 +63,7 @@ class ZLAlbumListModel: NSObject {
         self.isCameraRoll = isCameraRoll
     }
     
-    func refetchPhotos() {
+    public func refetchPhotos() {
         let models = ZLPhotoManager.fetchPhoto(in: self.result, ascending: ZLPhotoConfiguration.default().sortAscending, allowSelectImage: ZLPhotoConfiguration.default().allowSelectImage, allowSelectVideo:  ZLPhotoConfiguration.default().allowSelectVideo)
         self.models.removeAll()
         self.models.append(contentsOf: models)

--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -164,7 +164,7 @@ public class ZLPhotoManager: NSObject {
     }
     
     /// Fetch camera roll album.
-    class func getCameraRollAlbum(allowSelectImage: Bool, allowSelectVideo: Bool, completion: @escaping ( (ZLAlbumListModel) -> Void )) {
+    public class func getCameraRollAlbum(allowSelectImage: Bool, allowSelectVideo: Bool, completion: @escaping ( (ZLAlbumListModel) -> Void )) {
         let option = PHFetchOptions()
         if !allowSelectImage {
             option.predicate = NSPredicate(format: "mediaType == %ld", PHAssetMediaType.video.rawValue)
@@ -246,7 +246,7 @@ public class ZLPhotoManager: NSObject {
     }
     
     @discardableResult
-    class func fetchImage(for asset: PHAsset, size: CGSize, progress: ( (CGFloat, Error?, UnsafeMutablePointer<ObjCBool>, [AnyHashable : Any]?) -> Void )? = nil, completion: @escaping ( (UIImage?, Bool) -> Void )) -> PHImageRequestID {
+    public class func fetchImage(for asset: PHAsset, size: CGSize, progress: ( (CGFloat, Error?, UnsafeMutablePointer<ObjCBool>, [AnyHashable : Any]?) -> Void )? = nil, completion: @escaping ( (UIImage?, Bool) -> Void )) -> PHImageRequestID {
         return self.fetchImage(for: asset, size: size, resizeMode: .fast, progress: progress, completion: completion)
     }
     

--- a/Sources/General/ZLPhotoModel.swift
+++ b/Sources/General/ZLPhotoModel.swift
@@ -29,7 +29,7 @@ import Photos
 
 extension ZLPhotoModel {
     
-    enum MediaType: Int {
+    public enum MediaType: Int {
         case unknown = 0
         case image
         case gif
@@ -40,32 +40,32 @@ extension ZLPhotoModel {
 }
 
 
-class ZLPhotoModel: NSObject {
+public class ZLPhotoModel: NSObject {
 
-    let ident: String
+    public let ident: String
     
-    let asset: PHAsset
+    public let asset: PHAsset
     
-    var type: ZLPhotoModel.MediaType = .unknown
+    public var type: ZLPhotoModel.MediaType = .unknown
     
-    var duration: String = ""
+    public var duration: String = ""
     
-    var isSelected: Bool = false
+    public var isSelected: Bool = false
     
-    var editImage: UIImage?
+    public var editImage: UIImage?
     
-    var second: Second {
+    public var second: Second {
         guard type == .video else {
             return 0
         }
         return Int(round(asset.duration))
     }
     
-    var whRatio: CGFloat {
+    public var whRatio: CGFloat {
         return CGFloat(self.asset.pixelWidth) / CGFloat(self.asset.pixelHeight)
     }
     
-    var previewSize: CGSize {
+    public var previewSize: CGSize {
         let scale: CGFloat = 2 //UIScreen.main.scale
         if self.whRatio > 1 {
             let h = min(UIScreen.main.bounds.height, ZLMaxImageWidth) * scale
@@ -79,9 +79,9 @@ class ZLPhotoModel: NSObject {
     }
     
     // Content of the last edit.
-    var editImageModel: ZLEditImageModel?
+    public var editImageModel: ZLEditImageModel?
     
-    init(asset: PHAsset) {
+    public init(asset: PHAsset) {
         self.ident = asset.localIdentifier
         self.asset = asset
         super.init()
@@ -92,7 +92,7 @@ class ZLPhotoModel: NSObject {
         }
     }
     
-    func transformAssetType(for asset: PHAsset) -> ZLPhotoModel.MediaType {
+    public func transformAssetType(for asset: PHAsset) -> ZLPhotoModel.MediaType {
         switch asset.mediaType {
         case .video:
             return .video
@@ -111,7 +111,7 @@ class ZLPhotoModel: NSObject {
         }
     }
     
-    func transformDuration(for asset: PHAsset) -> String {
+    public func transformDuration(for asset: PHAsset) -> String {
         let dur = Int(round(asset.duration))
         
         switch dur {
@@ -134,6 +134,6 @@ class ZLPhotoModel: NSObject {
 }
 
 
-func ==(lhs: ZLPhotoModel, rhs: ZLPhotoModel) -> Bool {
+public func ==(lhs: ZLPhotoModel, rhs: ZLPhotoModel) -> Bool {
     return lhs.ident == rhs.ident
 }


### PR DESCRIPTION
Hi  long：

我一直使用你的库来做获取相册照片的逻辑（因为项目中要使用自己自定义的相册UI），但我升级到swift版本之后，发现之前那些获取照片列表的func都不能使用了，比如`getCameraRollAlbum`，因为默认的权限类型是internal。所以我只能在使用回oc的版本或者抽取某些代码方法我的项目源码中。

在本次提交中只是修改了我暂时使用到的`getCameraRollAlbum`这个方法，我把他的类型设置为了public，同时也牵连的修改了`ZLAlbumListModel`和`ZLPhotoModel`。

一点建议：
1. 希望能做一下UI层和逻辑层的分离，这样想我这种只需要逻辑的需求，就可以只导入逻辑部分
2. 公开某些逻辑层的权限，让我们可以随意调用 

我并没有很仔细的阅读您的源码，暂时只是一个使用者的角度来谈的问题，所以可能上面所说的并不正确，也可能您是故意隐藏了这些方法，但确实存在我们这种仅仅需要逻辑的需求。

希望项目会越来越好，也希望自己有机会继续贡献代码。

Thanks

