### PR TITLE
Fix some bugs

### DIFF
--- a/Sources/General/ZLImagePreviewController.swift
+++ b/Sources/General/ZLImagePreviewController.swift
@@ -311,7 +311,7 @@ public class ZLImagePreviewController: UIViewController {
     
     @objc func selectBtnClick() {
         var isSelected = self.selectStatus[self.currentIndex]
-        
+        self.selectBtn.layer.removeAllAnimations()
         if isSelected {
             isSelected = false
         } else {

--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -392,11 +392,6 @@ public class ZLPhotoManager: NSObject {
             completion(path)
         }
     }
-    
-    @objc public class func cancelImageRequest(_ requestID: PHImageRequestID) {
-        PHImageManager.default().cancelImageRequest(requestID)
-    }
-    
 }
 
 

--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -393,6 +393,10 @@ public class ZLPhotoManager: NSObject {
         }
     }
     
+    @objc public class func cancelImageRequest(_ requestID: PHImageRequestID) {
+        PHImageManager.default().cancelImageRequest(requestID)
+    }
+    
 }
 
 

--- a/Sources/General/ZLPhotoPreviewCell.swift
+++ b/Sources/General/ZLPhotoPreviewCell.swift
@@ -969,12 +969,14 @@ class ZLPreviewView: UIView {
             guard self?.imageIdentifier == self?.model.ident else {
                 return
             }
-            if let imageRequestID = self?.imageRequestID {
-                PHImageManager.default().cancelImageRequest(imageRequestID)
-            }
             if !isDegraded {
                 self?.fetchGifDone = true
-                self?.imageView.image = UIImage.zl_animateGifImage(data: data)
+                if let gifImage = UIImage.zl_animateGifImage(data: data) {
+                    if let imageRequestID = self?.imageRequestID {
+                        PHImageManager.default().cancelImageRequest(imageRequestID)
+                    }
+                    self?.imageView.image = gifImage
+                }
                 self?.resetSubViewSize()
             }
         })

--- a/Sources/General/ZLPhotoPreviewCell.swift
+++ b/Sources/General/ZLPhotoPreviewCell.swift
@@ -970,7 +970,7 @@ class ZLPreviewView: UIView {
                 return
             }
             if let imageRequestID = self?.imageRequestID {
-                ZLPhotoManager.cancelImageRequest(imageRequestID)
+                PHImageManager.default().cancelImageRequest(imageRequestID)
             }
             if !isDegraded {
                 self?.fetchGifDone = true

--- a/Sources/General/ZLPhotoPreviewCell.swift
+++ b/Sources/General/ZLPhotoPreviewCell.swift
@@ -969,6 +969,9 @@ class ZLPreviewView: UIView {
             guard self?.imageIdentifier == self?.model.ident else {
                 return
             }
+            if let imageRequestID = self?.imageRequestID {
+                ZLPhotoManager.cancelImageRequest(imageRequestID)
+            }
             if !isDegraded {
                 self?.fetchGifDone = true
                 self?.imageView.image = UIImage.zl_animateGifImage(data: data)

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -111,7 +111,7 @@ class ZLPhotoPreviewController: UIViewController {
         self.setupUI()
         
         self.addPopInteractiveTransition()
-        self.resetSubViewStatus(animateIndexLabel: false)
+        self.resetSubViewStatus()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -246,7 +246,7 @@ class ZLPhotoPreviewController: UIViewController {
         self.indexLabel.layer.cornerRadius = 25.0 / 2
         self.indexLabel.layer.masksToBounds = true
         self.indexLabel.isHidden = true
-        self.navView.addSubview(self.indexLabel)
+        self.selectBtn.addSubview(self.indexLabel)
         
         // collection view
         let layout = UICollectionViewFlowLayout()
@@ -368,7 +368,7 @@ class ZLPhotoPreviewController: UIViewController {
         }
     }
     
-    func resetSubViewStatus(animateIndexLabel: Bool) {
+    func resetSubViewStatus() {
         let nav = self.navigationController as! ZLImageNavController
         let config = ZLPhotoConfiguration.default()
         let currentModel = self.arrDataSources[self.currentIndex]
@@ -379,7 +379,7 @@ class ZLPhotoPreviewController: UIViewController {
             self.selectBtn.isHidden = false
         }
         self.selectBtn.isSelected = self.arrDataSources[self.currentIndex].isSelected
-        self.resetIndexLabelStatus(animate: animateIndexLabel)
+        self.resetIndexLabelStatus()
         
         guard self.showBottomViewAndSelectBtn else {
             self.selectBtn.isHidden = true
@@ -412,7 +412,7 @@ class ZLPhotoPreviewController: UIViewController {
         }
     }
     
-    func resetIndexLabelStatus(animate: Bool) {
+    func resetIndexLabelStatus() {
         guard ZLPhotoConfiguration.default().showSelectedIndex else {
             self.indexLabel.isHidden = true
             return
@@ -423,9 +423,6 @@ class ZLPhotoPreviewController: UIViewController {
             self.indexLabel.text = String(index + 1)
         } else {
             self.indexLabel.isHidden = true
-        }
-        if animate {
-            self.indexLabel.layer.add(getSpringAnimation(), forKey: nil)
         }
     }
     
@@ -456,7 +453,7 @@ class ZLPhotoPreviewController: UIViewController {
             nav.arrSelectedModels.append(currentModel)
             self.selPhotoPreview?.addSelModel(model: currentModel)
         }
-        self.resetSubViewStatus(animateIndexLabel: true)
+        self.resetSubViewStatus()
     }
     
     @objc func editBtnClick() {
@@ -542,7 +539,7 @@ class ZLPhotoPreviewController: UIViewController {
         guard ZLPhotoConfiguration.default().showSelectedIndex else {
             return
         }
-        self.resetIndexLabelStatus(animate: false)
+        self.resetIndexLabelStatus()
     }
     
     func tapPreviewCell() {
@@ -567,7 +564,7 @@ class ZLPhotoPreviewController: UIViewController {
             if nav?.arrSelectedModels.contains(where: { $0 == model }) == false {
                 model.isSelected = true
                 nav?.arrSelectedModels.append(model)
-                self.resetSubViewStatus(animateIndexLabel: false)
+                self.resetSubViewStatus()
                 self.selPhotoPreview?.addSelModel(model: model)
             } else {
                 self.selPhotoPreview?.refreshCell(for: model)
@@ -637,7 +634,7 @@ extension ZLPhotoPreviewController {
             return
         }
         self.currentIndex = page
-        self.resetSubViewStatus(animateIndexLabel: false)
+        self.resetSubViewStatus()
         self.selPhotoPreview?.currentShowModelChanged(model: self.arrDataSources[self.currentIndex])
     }
     

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -819,11 +819,8 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
     func addSelModel(model: ZLPhotoModel) {
         self.arrSelectedModels.append(model)
         let ip = IndexPath(row: self.arrSelectedModels.count-1, section: 0)
-        self.collectionView.performBatchUpdates({
-            self.collectionView.insertItems(at: [ip])
-        }) { (_) in
-            self.collectionView.scrollToItem(at: ip, at: .centeredHorizontally, animated: true)
-        }
+        self.collectionView.insertItems(at: [ip])
+        self.collectionView.scrollToItem(at: ip, at: .centeredHorizontally, animated: true)
     }
     
     func removeSelModel(model: ZLPhotoModel) {
@@ -831,9 +828,10 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
             return
         }
         self.arrSelectedModels.remove(at: index)
-        self.collectionView.performBatchUpdates({
-            self.collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
-        }, completion: nil)
+        self.collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
+        if index > 0 {
+            self.collectionView.scrollToItem(at: IndexPath(row: index - 1, section: 0), at: .centeredHorizontally, animated: true)
+        }
     }
     
     func refreshCell(for model: ZLPhotoModel) {

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -442,7 +442,7 @@ class ZLPhotoPreviewController: UIViewController {
     @objc func selectBtnClick() {
         let nav = self.navigationController as! ZLImageNavController
         let currentModel = self.arrDataSources[self.currentIndex]
-        
+        self.selectBtn.layer.removeAllAnimations()
         if currentModel.isSelected {
             currentModel.isSelected = false
             nav.arrSelectedModels.removeAll { $0 == currentModel }

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -826,9 +826,6 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
         }
         self.arrSelectedModels.remove(at: index)
         self.collectionView.deleteItems(at: [IndexPath(row: index, section: 0)])
-        if index > 0 {
-            self.collectionView.scrollToItem(at: IndexPath(row: index - 1, section: 0), at: .centeredHorizontally, animated: true)
-        }
     }
     
     func refreshCell(for model: ZLPhotoModel) {

--- a/Sources/General/ZLPhotoPreviewSheet.swift
+++ b/Sources/General/ZLPhotoPreviewSheet.swift
@@ -815,7 +815,7 @@ extension ZLPhotoPreviewSheet: UICollectionViewDataSource, UICollectionViewDeleg
         if ZLPhotoConfiguration.default().showSelectedIndex {
             for (index, selM) in self.arrSelectedModels.enumerated() {
                 if model == selM {
-                    self.setCellIndex(cell, showIndexLabel: true, index: index + 1, animate: false)
+                    self.setCellIndex(cell, showIndexLabel: true, index: index + 1)
                     break
                 }
             }
@@ -908,15 +908,12 @@ extension ZLPhotoPreviewSheet: UICollectionViewDataSource, UICollectionViewDeleg
         return flag && (canEditImage || canEditVideo)
     }
     
-    func setCellIndex(_ cell: ZLThumbnailPhotoCell?, showIndexLabel: Bool, index: Int, animate: Bool) {
+    func setCellIndex(_ cell: ZLThumbnailPhotoCell?, showIndexLabel: Bool, index: Int) {
         guard ZLPhotoConfiguration.default().showSelectedIndex else {
             return
         }
         cell?.index = index
         cell?.indexLabel.isHidden = !showIndexLabel
-        if animate {
-            cell?.indexLabel.layer.add(getSpringAnimation(), forKey: nil)
-        }
     }
     
     func refreshCellIndex() {
@@ -947,7 +944,7 @@ extension ZLPhotoPreviewSheet: UICollectionViewDataSource, UICollectionViewDeleg
                 }
             }
             if showIndex {
-                self.setCellIndex(cell, showIndexLabel: show, index: idx, animate: false)
+                self.setCellIndex(cell, showIndexLabel: show, index: idx)
             }
             if showMask {
                 self.setCellMaskView(cell, isSelected: isSelected, model: m)

--- a/Sources/General/ZLThumbnailPhotoCell.swift
+++ b/Sources/General/ZLThumbnailPhotoCell.swift
@@ -110,7 +110,7 @@ class ZLThumbnailPhotoCell: UICollectionViewCell {
         self.indexLabel.adjustsFontSizeToFitWidth = true
         self.indexLabel.minimumScaleFactor = 0.5
         self.indexLabel.textAlignment = .center
-        self.contentView.addSubview(self.indexLabel)
+        self.btnSelect.addSubview(self.indexLabel)
         
         self.bottomShadowView = UIImageView(image: getImage("zl_shadow"))
         self.contentView.addSubview(self.bottomShadowView)
@@ -143,7 +143,7 @@ class ZLThumbnailPhotoCell: UICollectionViewCell {
         self.imageView.frame = self.bounds
         self.coverView.frame = self.bounds
         self.btnSelect.frame = CGRect(x: self.bounds.width - 30, y: 8, width: 23, height: 23)
-        self.indexLabel.frame = self.btnSelect.frame
+        self.indexLabel.frame = self.btnSelect.bounds
         self.bottomShadowView.frame = CGRect(x: 0, y: self.bounds.height - 25, width: self.bounds.width, height: 25)
         self.videoTag.frame = CGRect(x: 5, y: 1, width: 20, height: 15)
         self.livePhotoTag.frame = CGRect(x: 5, y: -1, width: 20, height: 20)

--- a/Sources/General/ZLThumbnailPhotoCell.swift
+++ b/Sources/General/ZLThumbnailPhotoCell.swift
@@ -159,6 +159,7 @@ class ZLThumbnailPhotoCell: UICollectionViewCell {
             return
         }
         
+        self.btnSelect.layer.removeAllAnimations()
         if !self.btnSelect.isSelected {
             self.btnSelect.layer.add(getSpringAnimation(), forKey: nil)
         }

--- a/Sources/General/ZLThumbnailViewController.swift
+++ b/Sources/General/ZLThumbnailViewController.swift
@@ -961,7 +961,7 @@ extension ZLThumbnailViewController: UICollectionViewDataSource, UICollectionVie
         if ZLPhotoConfiguration.default().showSelectedIndex {
             for (index, selM) in (nav?.arrSelectedModels ?? []).enumerated() {
                 if model == selM {
-                    self.setCellIndex(cell, showIndexLabel: true, index: index + 1, animate: false)
+                    self.setCellIndex(cell, showIndexLabel: true, index: index + 1)
                     break
                 }
             }
@@ -1057,15 +1057,12 @@ extension ZLThumbnailViewController: UICollectionViewDataSource, UICollectionVie
         return flag && (canEditImage || canEditVideo)
     }
     
-    func setCellIndex(_ cell: ZLThumbnailPhotoCell?, showIndexLabel: Bool, index: Int, animate: Bool) {
+    func setCellIndex(_ cell: ZLThumbnailPhotoCell?, showIndexLabel: Bool, index: Int) {
         guard ZLPhotoConfiguration.default().showSelectedIndex else {
             return
         }
         cell?.index = index
         cell?.indexLabel.isHidden = !showIndexLabel
-        if animate {
-            cell?.indexLabel.layer.add(getSpringAnimation(), forKey: nil)
-        }
     }
     
     func refreshCellIndexAndMaskView() {
@@ -1101,7 +1098,7 @@ extension ZLThumbnailViewController: UICollectionViewDataSource, UICollectionVie
                 }
             }
             if showIndex {
-                self.setCellIndex(cell, showIndexLabel: show, index: idx, animate: false)
+                self.setCellIndex(cell, showIndexLabel: show, index: idx)
             }
             if showMask {
                 self.setCellMaskView(cell, isSelected: isSelected, model: m)


### PR DESCRIPTION
1. Continuous click to select button to cause crash.
    `IndexPath` has changed when `scrollToItem` is executed asynchronously
3. Switching the preview image in a click bottom `ZLPhotoPreviewSelectedView` caused GIF has frozen.
   `loadGifFirstFrame` last callback than `loadGifData` callback is later.
4. Remove the `selectBtn` animation when unselected.
5. Move `indexLabel` to the subView of `selectBtn` to solve the problem of spring animation coveraged.