### PR TITLE
修复bug，

### DIFF
--- a/Sources/General/ZLPhotoPreviewCell.swift
+++ b/Sources/General/ZLPhotoPreviewCell.swift
@@ -719,7 +719,9 @@ class ZLNetVideoPreviewCell: ZLPreviewBaseCell {
         self.playerLayer?.removeFromSuperlayer()
         self.playerLayer = nil
         
-        let asset = AVURLAsset(url: videoUrl, options: ["AVURLAssetHTTPHeaderFieldsKey": httpHeader as Any])
+        var options: [String : Any] = [:]
+        options["AVURLAssetHTTPHeaderFieldsKey"] = httpHeader
+        let asset = AVURLAsset(url: videoUrl, options: options)
         let item = AVPlayerItem(asset: asset)
         self.player = AVPlayer(playerItem: item)
         self.playerLayer = AVPlayerLayer(player: self.player)


### PR DESCRIPTION
场景：
在模拟器 iPhone 12 Pro，iOS 14.4 (18D46)运行时，进入“preview local and net image”页面后，往后滑动，在cell加载视频时会崩溃。

原因：
初始化AVURLAsset时options传入["AVURLAssetHTTPHeaderFieldsKey": httpHeader as Any]，但httpHeader为nil导致的崩溃。
swift中允许字典value值为nil，即可通过字面量创建的字典dic = ["key":nil]，但通过dic["key"] = nil 则不会吧nil存进字典。
AVURLAsset是通过OC实现的，oc不允许字典值为nil，因此AVURLAsset在拿到该options字典进行转存 即copy时，
会报错[NSNull _cfMutableCopy]: unrecognized selector sent to instance。