### PR TITLE
修复图片预览一些小bug

### DIFF
--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -1014,12 +1014,6 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
         let m = arrSelectedModels[indexPath.row]
         cell.model = m
         
-        if m == currentShowModel {
-            cell.layer.borderWidth = 4
-        } else {
-            cell.layer.borderWidth = 0
-        }
-        
         return cell
     }
     
@@ -1035,6 +1029,15 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
             self.collectionView.reloadItems(at: self.collectionView.indexPathsForVisibleItems)
         }
         selectBlock?(m)
+    }
+
+    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let m = arrSelectedModels[indexPath.row]
+        if m == currentShowModel {
+            cell.layer.borderWidth = 4
+        } else {
+            cell.layer.borderWidth = 0
+        }
     }
 }
 

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -1003,6 +1003,11 @@ class ZLPhotoPreviewSelectedView: UIView, UICollectionViewDataSource, UICollecti
             endSortBlock?(arrSelectedModels)
         }
     }
+
+    @available(iOS 11.0, *)
+    func collectionView(_ collectionView: UICollectionView, dragSessionDidEnd session: UIDragSession) {
+        isDraging = false
+    }
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return arrSelectedModels.count


### PR DESCRIPTION
bug

- 修复图片预览滑动后选择其它时, 滑动返回之前的位置没有取消选择
- 修复图片预览长按拖动到非其它图片预览位置(不触发换位置)后, 拖动状态不重置, 导致无法切换选择图片