### PR TITLE
keep alpha channel

### DIFF
--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -298,7 +298,7 @@ public class ZLPhotoManager: NSObject {
     /// Fetch image for asset.
     private class func fetchImage(for asset: PHAsset, size: CGSize, resizeMode: PHImageRequestOptionsResizeMode, progress: ((CGFloat, Error?, UnsafeMutablePointer<ObjCBool>, [AnyHashable: Any]?) -> Void)? = nil, completion: @escaping (UIImage?, Bool) -> Void) -> PHImageRequestID {
         let option = PHImageRequestOptions()
-        if ZLPhotoConfiguration.default().alwaysRequestOriginal {
+        if ZLPhotoConfiguration.default().alwaysRequestOriginal && asset.mediaType == .image {
             option.version = .original // original得到的image才会有alpha channel
         }
         option.resizeMode = resizeMode

--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -287,6 +287,9 @@ public class ZLPhotoManager: NSObject {
     /// Fetch image for asset.
     private class func fetchImage(for asset: PHAsset, size: CGSize, resizeMode: PHImageRequestOptionsResizeMode, progress: ((CGFloat, Error?, UnsafeMutablePointer<ObjCBool>, [AnyHashable: Any]?) -> Void)? = nil, completion: @escaping (UIImage?, Bool) -> Void) -> PHImageRequestID {
         let option = PHImageRequestOptions()
+        if ZLPhotoConfiguration.default().alwaysRequestOriginal {
+            option.version = .original // original得到的image才会有alpha channel
+        }
         option.resizeMode = resizeMode
         option.isNetworkAccessAllowed = true
         option.progressHandler = { pro, error, stop, info in


### PR DESCRIPTION
优化带有alpha通道的png图片展示和编辑

1.  让png图片在Preview页面可以显示alpha通道。
2. 编辑后可保留alpha channel，尝试解决 https://github.com/longitachi/ZLPhotoBrowser/issues/170 。但是对于非编辑情况的图片保存可能考虑的不全面，因为会把png格式作为默认的保存格式。

这两处修改都会导致之前的功能发生变化，可能需要新增配置字段。