### PR TITLE
Disable TextView when user ends editing

### DIFF
--- a/Sources/Edit/ZLInputTextViewController.swift
+++ b/Sources/Edit/ZLInputTextViewController.swift
@@ -256,7 +256,8 @@ class ZLInputTextViewController: UIViewController {
     
     @objc private func doneBtnClick() {
         textView.tintColor = .clear
-        
+        textView.endEditing(true)
+
         var image: UIImage?
         
         if !textView.text.isEmpty {


### PR DESCRIPTION
I've encountered an issue.

I can see whenever user selects text on a final image, or the end cursor.

This PR fixes this problem

<img width="414" alt="image" src="https://github.com/longitachi/ZLPhotoBrowser/assets/23390884/78f2e22a-9727-4524-b52b-c60298e01615">
