### PR TITLE
Maintain shadow background during photo clipping

### DIFF
--- a/Sources/Edit/ZLClipImageViewController.swift
+++ b/Sources/Edit/ZLClipImageViewController.swift
@@ -54,6 +54,8 @@ class ZLClipImageViewController: UIViewController {
     
     private let clipRatios: [ZLImageClipRatio]
     
+    private let dimClippedAreaDuringAdjustments: Bool
+
     private var editImage: UIImage
     
     /// 初次进入界面时候，裁剪范围
@@ -85,14 +87,14 @@ class ZLClipImageViewController: UIViewController {
     private lazy var shadowView: ZLClipShadowView = {
         let view = ZLClipShadowView()
         view.isUserInteractionEnabled = false
-        view.backgroundColor = UIColor.black.withAlphaComponent(0.3)
+        view.backgroundColor = .clear
+        view.isCircle = selectedRatio.isCircle
         return view
     }()
     
     private lazy var overlayView: ZLClipOverlayView = {
         let view = ZLClipOverlayView()
         view.isUserInteractionEnabled = false
-        view.isCircle = selectedRatio.isCircle
         return view
     }()
     
@@ -189,7 +191,7 @@ class ZLClipImageViewController: UIViewController {
     
     private var selectedRatio: ZLImageClipRatio {
         didSet {
-            overlayView.isCircle = selectedRatio.isCircle
+            shadowView.isCircle = selectedRatio.isCircle
         }
     }
     
@@ -231,7 +233,9 @@ class ZLClipImageViewController: UIViewController {
     
     init(image: UIImage, editRect: CGRect?, angle: CGFloat = 0, selectRatio: ZLImageClipRatio?) {
         originalImage = image
-        clipRatios = ZLPhotoConfiguration.default().editImageConfiguration.clipRatios
+        let configuration = ZLPhotoConfiguration.default().editImageConfiguration
+        clipRatios = configuration.clipRatios
+        dimClippedAreaDuringAdjustments = configuration.dimClippedAreaDuringAdjustments
         self.editRect = editRect ?? .zero
         self.angle = angle
         let angle = ((Int(angle) % 360) - 360) % 360
@@ -298,6 +302,7 @@ class ZLClipImageViewController: UIViewController {
                 UIView.animate(withDuration: 0.1, animations: {
                     self.mainScrollView.alpha = 1
                     self.overlayView.alpha = 1
+                    self.shadowView.alpha = 1
                 }) { _ in
                     animateImageView.removeFromSuperview()
                 }
@@ -307,6 +312,7 @@ class ZLClipImageViewController: UIViewController {
             rotateBtn.alpha = 1
             mainScrollView.alpha = 1
             overlayView.alpha = 1
+            shadowView.alpha = 1
         }
     }
     
@@ -374,6 +380,7 @@ class ZLClipImageViewController: UIViewController {
         
         mainScrollView.alpha = 0
         overlayView.alpha = 0
+        shadowView.alpha = 0
         bottomToolView.alpha = 0
         rotateBtn.alpha = 0
     }
@@ -594,6 +601,7 @@ class ZLClipImageViewController: UIViewController {
         let toFrame = view.convert(containerView.frame, from: mainScrollView)
         let transform = CGAffineTransform(rotationAngle: -CGFloat.pi / 2)
         overlayView.alpha = 0
+        shadowView.alpha = 0
         containerView.alpha = 0
         UIView.animate(withDuration: 0.3, animations: {
             animateImageView.transform = transform
@@ -602,6 +610,7 @@ class ZLClipImageViewController: UIViewController {
             animateImageView.removeFromSuperview()
             self.overlayView.alpha = 1
             self.containerView.alpha = 1
+            self.shadowView.alpha = 1
             self.isRotating = false
         }
         
@@ -816,7 +825,9 @@ class ZLClipImageViewController: UIViewController {
     
     private func startEditing() {
         cleanTimer()
-        shadowView.alpha = 0
+        if !dimClippedAreaDuringAdjustments {
+            shadowView.alpha = 0
+        }
         overlayView.isEditing = true
         if rotateBtn.alpha != 0 {
             rotateBtn.layer.removeAllAnimations()
@@ -883,7 +894,9 @@ class ZLClipImageViewController: UIViewController {
             }
             self.rotateBtn.alpha = 1
             self.clipRatioColView.alpha = 1
-            self.shadowView.alpha = 1
+            if !self.dimClippedAreaDuringAdjustments {
+                self.shadowView.alpha = 1
+            }
             self.changeClipBoxFrame(newFrame: clipRect)
         }
     }
@@ -1099,32 +1112,58 @@ class ZLImageClipRatioCell: UICollectionViewCell {
 }
 
 class ZLClipShadowView: UIView {
-    var clearRect: CGRect = .zero {
+    var isCircle: Bool = false {
         didSet {
-            self.setNeedsDisplay()
+            (layer as? ZLClipShadowViewLayer)?.isCircle = isCircle
         }
     }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .clear
-        isOpaque = false
+    var clearRect: CGRect = .zero {
+        didSet {
+            (layer as? ZLClipShadowViewLayer)?.clearRect = clearRect
+        }
     }
     
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+    override class var layerClass: AnyClass {
+        return ZLClipShadowViewLayer.self
     }
     
-    override func draw(_ rect: CGRect) {
-        UIColor(white: 0, alpha: 0.7).setFill()
-        UIRectFill(rect)
-        let cr = clearRect.intersection(rect)
-        UIColor.clear.setFill()
-        UIRectFill(cr)
+    override func action(for layer: CALayer, forKey event: String) -> CAAction? {
+        guard event == #keyPath(ZLClipShadowViewLayer.clearRect),
+              let action = super.action(for: layer, forKey: #keyPath(backgroundColor)) as? CAAnimation,
+              let animation: CABasicAnimation = (action.copy() as? CABasicAnimation) else {
+            return super.action(for: layer, forKey: event)
+        }
+        animation.keyPath = #keyPath(ZLClipShadowViewLayer.clearRect)
+        animation.fromValue = (layer as? ZLClipShadowViewLayer)?.clearRect
+        animation.toValue = clearRect
+        layer.add(animation, forKey: #keyPath(ZLClipShadowViewLayer.clearRect))
+        return animation
+    }
+    
+    override func draw(_ layer: CALayer, in ctx: CGContext) {
+        guard let shadowLayer = layer as? ZLClipShadowViewLayer else {
+            return super.draw(layer, in: ctx)
+        }
+        ctx.setFillColor(UIColor(white: 0, alpha: 0.7).cgColor)
+        ctx.fill(layer.frame)
+        if !isCircle {
+            ctx.clear(shadowLayer.clearRect)
+        } else {
+            ctx.setBlendMode(.clear)
+            ctx.setFillColor(UIColor.clear.cgColor)
+            ctx.fillEllipse(in: shadowLayer.clearRect)
+        }
     }
 }
 
+class ZLClipShadowViewLayer: CALayer {
+    @NSManaged var clearRect: CGRect
+    @NSManaged var isCircle: Bool
+    override class func needsDisplay(forKey key: String) -> Bool {
+        return super.needsDisplay(forKey: key) || key == #keyPath(clearRect) || key == #keyPath(isCircle)
+    }
+}
 // MARK: 裁剪网格视图
 
 class ZLClipOverlayView: UIView {
@@ -1136,23 +1175,7 @@ class ZLClipOverlayView: UIView {
     
     private var horLines: [UIView] = []
     
-    var isCircle = false {
-        didSet {
-            guard oldValue != isCircle else {
-                return
-            }
-            setNeedsDisplay()
-        }
-    }
-    
-    var isEditing = false {
-        didSet {
-            guard isCircle else {
-                return
-            }
-            setNeedsDisplay()
-        }
-    }
+    var isEditing = false
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -1258,46 +1281,11 @@ class ZLClipOverlayView: UIView {
         context?.setLineWidth(1)
         context?.beginPath()
         
-        if isCircle {
-            let center = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
-            let radius = rect.width / 2 - ZLClipOverlayView.cornerLineWidth
-            if !isEditing {
-                // top left
-                context?.move(to: CGPoint(x: ZLClipOverlayView.cornerLineWidth, y: ZLClipOverlayView.cornerLineWidth))
-                context?.addLine(to: CGPoint(x: rect.width / 2, y: rect.origin.y + 3))
-                context?.addArc(center: center, radius: radius, startAngle: .pi * 1.5, endAngle: .pi, clockwise: true)
-                context?.closePath()
-                
-                // top right
-                context?.move(to: CGPoint(x: rect.width - ZLClipOverlayView.cornerLineWidth, y: ZLClipOverlayView.cornerLineWidth))
-                context?.addLine(to: CGPoint(x: rect.width - ZLClipOverlayView.cornerLineWidth, y: rect.height / 2))
-                context?.addArc(center: center, radius: radius, startAngle: 0, endAngle: .pi * 1.5, clockwise: true)
-                context?.closePath()
-                
-                // bottom left
-                context?.move(to: CGPoint(x: ZLClipOverlayView.cornerLineWidth, y: rect.height - ZLClipOverlayView.cornerLineWidth))
-                context?.addLine(to: CGPoint(x: ZLClipOverlayView.cornerLineWidth, y: rect.height / 2))
-                context?.addArc(center: center, radius: radius, startAngle: .pi, endAngle: .pi / 2, clockwise: true)
-                context?.closePath()
-                
-                // bottom right
-                context?.move(to: CGPoint(x: rect.width - ZLClipOverlayView.cornerLineWidth, y: rect.height - ZLClipOverlayView.cornerLineWidth))
-                context?.addLine(to: CGPoint(x: rect.width / 2, y: rect.height - ZLClipOverlayView.cornerLineWidth))
-                context?.addArc(center: center, radius: radius, startAngle: .pi / 2, endAngle: 0, clockwise: true)
-                context?.closePath()
-                
-                context?.setFillColor(UIColor.black.withAlphaComponent(0.7).cgColor)
-                context?.fillPath()
-            }
-            
-            context?.addArc(center: center, radius: radius, startAngle: 0, endAngle: .pi * 2, clockwise: false)
-        }
-        
         let circleDiff: CGFloat = (3 - 2 * sqrt(2)) * (rect.width - 2 * ZLClipOverlayView.cornerLineWidth) / 6
         
         var dw: CGFloat = 3
         for i in 0..<4 {
-            let isInnerLine = isCircle && 1...2 ~= i
+            let isInnerLine = 1...2 ~= i
             context?.move(to: CGPoint(x: rect.origin.x + dw, y: ZLClipOverlayView.cornerLineWidth + (isInnerLine ? circleDiff : 0)))
             context?.addLine(to: CGPoint(x: rect.origin.x + dw, y: rect.height - ZLClipOverlayView.cornerLineWidth - (isInnerLine ? circleDiff : 0)))
             dw += (rect.size.width - 6) / 3
@@ -1305,7 +1293,7 @@ class ZLClipOverlayView: UIView {
 
         var dh: CGFloat = 3
         for i in 0..<4 {
-            let isInnerLine = isCircle && 1...2 ~= i
+            let isInnerLine = 1...2 ~= i
             context?.move(to: CGPoint(x: ZLClipOverlayView.cornerLineWidth + (isInnerLine ? circleDiff : 0), y: rect.origin.y + dh))
             context?.addLine(to: CGPoint(x: rect.width - ZLClipOverlayView.cornerLineWidth - (isInnerLine ? circleDiff : 0), y: rect.origin.y + dh))
             dh += (rect.size.height - 6) / 3

--- a/Sources/Edit/ZLClipImageViewController.swift
+++ b/Sources/Edit/ZLClipImageViewController.swift
@@ -95,6 +95,7 @@ class ZLClipImageViewController: UIViewController {
     private lazy var overlayView: ZLClipOverlayView = {
         let view = ZLClipOverlayView()
         view.isUserInteractionEnabled = false
+        view.isCircle = selectedRatio.isCircle
         return view
     }()
     
@@ -191,6 +192,7 @@ class ZLClipImageViewController: UIViewController {
     
     private var selectedRatio: ZLImageClipRatio {
         didSet {
+            overlayView.isCircle = selectedRatio.isCircle
             shadowView.isCircle = selectedRatio.isCircle
         }
     }
@@ -1175,7 +1177,23 @@ class ZLClipOverlayView: UIView {
     
     private var horLines: [UIView] = []
     
-    var isEditing = false
+    var isCircle = false {
+        didSet {
+            guard oldValue != isCircle else {
+                return
+            }
+            setNeedsDisplay()
+        }
+    }
+    
+    var isEditing = false {
+        didSet {
+            guard isCircle else {
+                return
+            }
+            setNeedsDisplay()
+        }
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -1285,7 +1303,7 @@ class ZLClipOverlayView: UIView {
         
         var dw: CGFloat = 3
         for i in 0..<4 {
-            let isInnerLine = 1...2 ~= i
+            let isInnerLine = isCircle && 1...2 ~= i
             context?.move(to: CGPoint(x: rect.origin.x + dw, y: ZLClipOverlayView.cornerLineWidth + (isInnerLine ? circleDiff : 0)))
             context?.addLine(to: CGPoint(x: rect.origin.x + dw, y: rect.height - ZLClipOverlayView.cornerLineWidth - (isInnerLine ? circleDiff : 0)))
             dw += (rect.size.width - 6) / 3
@@ -1293,7 +1311,7 @@ class ZLClipOverlayView: UIView {
 
         var dh: CGFloat = 3
         for i in 0..<4 {
-            let isInnerLine = 1...2 ~= i
+            let isInnerLine = isCircle && 1...2 ~= i
             context?.move(to: CGPoint(x: ZLClipOverlayView.cornerLineWidth + (isInnerLine ? circleDiff : 0), y: rect.origin.y + dh))
             context?.addLine(to: CGPoint(x: rect.width - ZLClipOverlayView.cornerLineWidth - (isInnerLine ? circleDiff : 0), y: rect.origin.y + dh))
             dh += (rect.size.height - 6) / 3

--- a/Sources/General/ZLEditImageConfiguration.swift
+++ b/Sources/General/ZLEditImageConfiguration.swift
@@ -190,6 +190,10 @@ public class ZLEditImageConfiguration: NSObject {
     
     /// Whether to support redo in graffiti and mosaic tools. Defaults to false
     public var canRedo = false
+    
+    /// Whether to keep clipped area dimmed during adjustments. Defaults to false
+    public var dimClippedAreaDuringAdjustments = false
+
 }
 
 public extension ZLEditImageConfiguration {
@@ -312,6 +316,12 @@ public extension ZLEditImageConfiguration {
     @discardableResult
     func canRedo(_ value: Bool) -> ZLEditImageConfiguration {
         canRedo = value
+        return self
+    }
+    
+    @discardableResult
+    func dimClippedAreaDuringAdjustments(_ value: Bool) -> ZLEditImageConfiguration {
+        dimClippedAreaDuringAdjustments = value
         return self
     }
 }


### PR DESCRIPTION
I wanted to keep the shadow visible all the time during photo clipping. Got it working well.

We can add a property so the user can decide if he want to see it or not, but for now I've decided to leave it as it is.

https://github.com/longitachi/ZLPhotoBrowser/assets/23390884/186acd10-8a81-473e-b74b-c764ff8c4e2e

