### PR TITLE
Zoom out photo in editor when aspect ratio match screen ratio

### DIFF
--- a/Sources/Edit/ZLEditImageViewController.swift
+++ b/Sources/Edit/ZLEditImageViewController.swift
@@ -183,6 +183,8 @@ open class ZLEditImageViewController: UIViewController {
     
     private let canRedo = ZLPhotoConfiguration.default().editImageConfiguration.canRedo
     
+    private let minimumZoomScale = ZLPhotoConfiguration.default().editImageConfiguration.minimumZoomScale
+    
     private var hasAdjustedImage = false
     
     // collectionview 中的添加滤镜的小图
@@ -258,7 +260,7 @@ open class ZLEditImageViewController: UIViewController {
     @objc public lazy var mainScrollView: UIScrollView = {
         let view = UIScrollView()
         view.backgroundColor = .black
-        view.minimumZoomScale = 1
+        view.minimumZoomScale = minimumZoomScale
         view.maximumZoomScale = 3
         view.delegate = self
         return view
@@ -542,6 +544,12 @@ open class ZLEditImageViewController: UIViewController {
         
         if let index = drawColors.firstIndex(where: { $0 == self.currentDrawColor }) {
             drawColorCollectionView?.scrollToItem(at: IndexPath(row: index, section: 0), at: .centeredHorizontally, animated: false)
+        }
+        
+        let contentRatio = mainScrollView.contentSize.width / mainScrollView.contentSize.height
+        let screenRatio = mainScrollView.bounds.size.width / mainScrollView.bounds.size.height
+        if abs(contentRatio - screenRatio) < 0.01 {
+            mainScrollView.setZoomScale(mainScrollView.minimumZoomScale, animated: true)
         }
     }
     

--- a/Sources/General/ZLEditImageConfiguration.swift
+++ b/Sources/General/ZLEditImageConfiguration.swift
@@ -194,6 +194,8 @@ public class ZLEditImageConfiguration: NSObject {
     /// Whether to keep clipped area dimmed during adjustments. Defaults to false
     public var dimClippedAreaDuringAdjustments = false
 
+    /// Minimum zoom scale, allowing the user to make the edited photo smaller, so it does not overlap top and bottom tools menu. Defaults to 1.0
+    public var minimumZoomScale = 1.0
 }
 
 public extension ZLEditImageConfiguration {

--- a/Sources/General/ZLEditImageConfiguration.swift
+++ b/Sources/General/ZLEditImageConfiguration.swift
@@ -326,6 +326,12 @@ public extension ZLEditImageConfiguration {
         dimClippedAreaDuringAdjustments = value
         return self
     }
+    
+    @discardableResult
+    func minimumZoomScale(_ value: CGFloat) -> ZLEditImageConfiguration {
+        minimumZoomScale = value
+        return self
+    }
 }
 
 // MARK: 裁剪比例


### PR DESCRIPTION
Issue: #852 

When user tries to edit a photo of a same resolution (for example a phone screenshot) then the photo is behind all the controls and user is unable to move it to clearly see the tools.

I've added an automatic zoom out functionality with minimumZoomScale option.