### PR TITLE
Fix Audio session

### DIFF
--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -1134,6 +1134,7 @@ open class ZLCustomCamera: UIViewController {
             return
         }
         try? AVAudioSession.sharedInstance().setCategory(.playback)
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         movieFileOutput.stopRecording()
     }
     

--- a/Sources/General/ZLPhotoPreviewCell.swift
+++ b/Sources/General/ZLPhotoPreviewCell.swift
@@ -538,6 +538,7 @@ class ZLVideoPreviewCell: ZLPreviewBaseCell {
     
     deinit {
         cancelDownloadVideo()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         zl_debugPrint("ZLVideoPreviewCell deinit")
     }
     
@@ -663,6 +664,8 @@ class ZLVideoPreviewCell: ZLPreviewBaseCell {
             }
             imageView.isHidden = true
             player?.play()
+            try? AVAudioSession.sharedInstance().setCategory(.playback)
+            try? AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
             playBtn.setImage(nil, for: .normal)
             singleTapBlock?()
         } else {
@@ -728,6 +731,7 @@ class ZLNetVideoPreviewCell: ZLPreviewBaseCell {
     private let operationQueue = DispatchQueue(label: "com.ZLPhotoBrowser.ZLNetVideoPreviewCell")
     
     deinit {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
         zl_debugPrint("ZLNetVideoPreviewCell deinit")
     }
     
@@ -766,6 +770,8 @@ class ZLNetVideoPreviewCell: ZLPreviewBaseCell {
                 player?.currentItem?.seek(to: CMTimeMake(value: 0, timescale: 1))
             }
             player?.play()
+            try? AVAudioSession.sharedInstance().setCategory(.playback)
+            try? AVAudioSession.sharedInstance().setActive(true, options: .notifyOthersOnDeactivation)
             playBtn.setImage(nil, for: .normal)
             singleTapBlock?()
         } else {


### PR DESCRIPTION
Audio Session was not working properly. I've ended up having an issue, when I went to gallery, wanted to play a video and it did not have an audio (my mute switch was enabled)

Whenever we need to play video (or from camera or video preview cell) we need to make sure we set up a correct category and we enable the session. We need to make sure we end up the session when we're done.

I've fixed this in this PR.

I was testing having a background music turned on and playing with camera and video preview. Music should stop and restart when we're listening to audio from ZLPhotoBrowser