### PR TITLE
Clip photo to circle

### DIFF
--- a/Sources/Extensions/UIImage+ZLPhotoBrowser.swift
+++ b/Sources/Extensions/UIImage+ZLPhotoBrowser.swift
@@ -416,7 +416,7 @@ public extension ZLPhotoBrowserWrapper where Base: UIImage {
         } else if a == -270 {
             newImage = rotate(orientation: .right)
         }
-        guard editRect.size != newImage.size else {
+        guard isCircle || editRect.size != newImage.size else {
             return newImage
         }
         


### PR DESCRIPTION
I have observed an issue. 

When you want to clip a photo to circle, but you will select a square photo, and you will not move the clipping tool at all, ZLPhotoBrowser will return original photo - not clipped to circle.

That's happening because if cropped size equals to original size ZLPhotoBrowser assumes there are no changes, but in fact, we want to cut out the clipped photo edges.

This simple change fixes this problem.