### PR TITLE
[Feature]: Batch Choose Image, When Edit It, Show the current image c…

### DIFF
--- a/Sources/General/ZLEditImageConfiguration.swift
+++ b/Sources/General/ZLEditImageConfiguration.swift
@@ -108,6 +108,10 @@ public class ZLEditImageConfiguration: NSObject {
         }
     }
     
+    /// When user batch choose images, and in preview page,  click Edit will show editor for that image, default will show all clipRatios for that image
+    /// when this property set true, it show the current image edit ratio only
+    public var showCurrentRatioWhenBatchClip: Bool = false
+    
     private var pri_textStickerTextColors: [UIColor] = ZLEditImageConfiguration.defaultColors
     /// Text sticker colors for image editor.
     public var textStickerTextColors: [UIColor] {

--- a/Sources/General/ZLPhotoConfiguration+Chaining.swift
+++ b/Sources/General/ZLPhotoConfiguration+Chaining.swift
@@ -305,6 +305,12 @@ public extension ZLPhotoConfiguration {
     }
     
     @discardableResult
+    func customAlertWhenNoAuthority(_ callback: (() -> Void)?) -> ZLPhotoConfiguration {
+        customAlertWhenNoAuthority = callback
+        return self
+    }
+    
+    @discardableResult
     func operateBeforeDoneAction(_ block: ((UIViewController, @escaping () -> Void) -> Void)?) -> ZLPhotoConfiguration {
         operateBeforeDoneAction = block
         return self

--- a/Sources/General/ZLPhotoConfiguration.swift
+++ b/Sources/General/ZLPhotoConfiguration.swift
@@ -256,6 +256,10 @@ public class ZLPhotoConfiguration: NSObject {
     /// Callback after the no authority alert dismiss.
     public var noAuthorityCallback: ((ZLNoAuthorityType) -> Void)?
     
+    /// Allow user to provide a custom alert while presenting ZLPhotoPreviewSheet with the authority is denied.
+    /// This will synchronously call the "noAuthorityCallback" callback
+    public var customAlertWhenNoAuthority: (() -> Void)?
+    
     /// Allow user to do something before select photo result callback.
     /// And you must call the second parameter of this block to continue the photos selection.
     /// The first parameter is the current controller.

--- a/Sources/General/ZLPhotoPreviewController.swift
+++ b/Sources/General/ZLPhotoPreviewController.swift
@@ -636,12 +636,23 @@ class ZLPhotoPreviewController: UIViewController {
             }
         }
         
+        let oldClipRatios = config.editImageConfiguration.clipRatios
         if model.type == .image || (!config.allowSelectGif && model.type == .gif) || (!config.allowSelectLivePhoto && model.type == .livePhoto) {
             hud.show(timeout: ZLPhotoUIConfiguration.default().timeout)
             requestAssetID = ZLPhotoManager.fetchImage(for: model.asset, size: model.previewSize) { [weak self] image, isDegraded in
                 if !isDegraded {
                     if let image = image {
+                        if config.editImageConfiguration.showCurrentRatioWhenBatchClip {
+                            let currentIndex = self?.currentIndex ?? 0
+                            var currentClip = ZLImageClipRatio.custom
+                            if oldClipRatios.count > currentIndex {
+                                currentClip = oldClipRatios[currentIndex]
+                                config.editImageConfiguration.clipRatios = [currentClip]
+                            }
+                        }
+                        
                         self?.showEditImageVC(image: image)
+                        config.editImageConfiguration.clipRatios = oldClipRatios
                     } else {
                         showAlertView(localLanguageTextValue(.imageLoadFailed), self)
                     }

--- a/Sources/General/ZLPhotoPreviewSheet.swift
+++ b/Sources/General/ZLPhotoPreviewSheet.swift
@@ -425,6 +425,12 @@ public class ZLPhotoPreviewSheet: UIView {
     }
     
     private func showNoAuthorityAlert() {
+        if let customAlertWhenNoAuthority = ZLPhotoConfiguration.default().customAlertWhenNoAuthority {
+            customAlertWhenNoAuthority()
+            ZLPhotoConfiguration.default().noAuthorityCallback?(.library)
+            return
+        }
+        
         let action = ZLCustomAlertAction(title: localLanguageTextValue(.ok), style: .default) { _ in
             ZLPhotoConfiguration.default().noAuthorityCallback?(.library)
         }


### PR DESCRIPTION
使用中发现， 批量选图之后，预览，编辑某张图， 会将所有 clipRatio 带到编辑页面， 实际我只想使用指定 ratio 编辑具体图。

此场景我在图片编辑的配置中，新增了 showCurrentRatioWhenBatchClip 属性。

如果代码符合作者要求，请合并一下， 🙏