### PR TITLE
fix PHPhotosErrorDomain Code=3164 error

### DIFF
--- a/Sources/General/ZLPhotoManager.swift
+++ b/Sources/General/ZLPhotoManager.swift
@@ -470,7 +470,9 @@ public class ZLPhotoManager: NSObject {
                 completion(error)
             } else if !isDegraded {
                 cleanTimer()
-                PHAssetResourceManager.default().writeData(for: resource, toFile: fileUrl, options: nil) { error in
+                let option = PHAssetResourceRequestOptions()
+                option.isNetworkAccessAllowed = true
+                PHAssetResourceManager.default().writeData(for: resource, toFile: fileUrl, options: option) { error in
                     ZLMainAsync {
                         completion(error)
                     }


### PR DESCRIPTION
当保存从icloud获取的图片时，报错PHPhotosErrorDomain Code=3164