### PR TITLE
fix(l10n): fix russian video record tips

### DIFF
--- a/Sources/ZLPhotoBrowser.bundle/ru.lproj/Localizable.strings
+++ b/Sources/ZLPhotoBrowser.bundle/ru.lproj/Localizable.strings
@@ -52,8 +52,8 @@
 "customCameraTips" = "Нажмите для съемки, удерживайте для записи";
 "customCameraTakePhotoTips" = "Нажмите для съeмки";
 "customCameraRecordVideoTips" = "Удерживайте для записи";
-"customCameraTapToRecordVideoTips" = "Нажмите, чтобы записать видео";
-"minRecordTimeTips" = "Запишите не менее 2 с";
+"customCameraTapToRecordVideoTips" = "Нажмите для записи";
+"minRecordTimeTips" = "Запишите не менее %ld с";
 
 "cameraRoll" = "Недавние";
 "panoramas" = "Панорамы";


### PR DESCRIPTION
Hey @longitachi

It's me again, just spotted 2 issues in the Russian translation string for video recording tips. The first one is related to the new `customCameraTapToRecordVideoTips` - to have it in sync with `customCameraTapToRecordVideoTips`/`customCameraTakePhotoTips`. The second is more important and is about hardcoded 2 seconds instead of actually one as in other langs. Thanks!