### PR TITLE
feat(camera): wide zoom cameras in custom camera

### DIFF
--- a/Sources/Extensions/AVCaptureDevice.swift
+++ b/Sources/Extensions/AVCaptureDevice.swift
@@ -1,0 +1,46 @@
+//
+//  AVCaptureDevice.swift
+//  ZLPhotoBrowser
+//
+//  Created by tsinis on 2024/11/1.
+//
+//  Copyright (c) 2020 Long Zhang <495181165@qq.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+import AVFoundation
+
+extension AVCaptureDevice {
+    var defaultZoomFactor: CGFloat {
+        let fallback: CGFloat = 1.0
+        guard #available(iOS 13.0, *) else { return fallback }
+
+        if let wideAngleIndex = self.constituentDevices.firstIndex(where: { $0.deviceType == .builtInWideAngleCamera }) {
+            guard wideAngleIndex >= 1 else { return fallback }
+            return CGFloat(self.virtualDeviceSwitchOverVideoZoomFactors[wideAngleIndex - 1].doubleValue)
+        }
+
+        return fallback
+    }
+
+    func normalizedZoomFactor(for zoomFactor: CGFloat) -> CGFloat {
+        zoomFactor / self.defaultZoomFactor
+    }
+}
+

--- a/Sources/General/ZLCameraConfiguration.swift
+++ b/Sources/General/ZLCameraConfiguration.swift
@@ -96,6 +96,10 @@ public class ZLCameraConfiguration: NSObject {
     /// If `allowTakePhoto` is true, `tapToRecordVideo` will be ignored.
     public var tapToRecordVideo: Bool = false
     
+    /// Enable the use of wide cameras (e.g., .builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera).
+    /// Defaults to false.
+    public var enableWideCameras: Bool = false
+    
     /// Video export format for recording video and editing video. Defaults to mov.
     public var videoExportType: ZLCameraConfiguration.VideoExportType = .mov
     
@@ -298,6 +302,12 @@ public extension ZLCameraConfiguration {
     @discardableResult
     func tapToRecordVideo(_ value: Bool) -> ZLCameraConfiguration {
         tapToRecordVideo = value
+        return self
+    }
+    
+    @discardableResult
+    func enableWideCameras(_ value: Bool) -> ZLCameraConfiguration {
+        enableWideCameras = value
         return self
     }
 }


### PR DESCRIPTION
Hey again @longitachi, thanks for reviewing my previous PRs, here is another one.

This PR introduces a new feature to the `ZLCustomCamera` that allows users to utilize wide cameras (e.g., .builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera). This enhancement is designed to improve the flexibility and functionality of the camera, especially for users who need to capture wider shots. And it's also a feature that exists in the original `UIImagePickerController` but is missing in `ZLCustomCamera`.

## Key Changes

- Added a new boolean property `enableWideCameras` to `ZLCameraConfiguration`.

- Updated the getCamera method in `ZLCustomCamera` to include the `cameraConfig.enableWideCameras` flag check along with the #available check.

- Modified the `setInitialZoomFactor` method in `ZLCustomCamera` to use an early return with the guard statement if `cameraConfig.enableWideCameras` is false.

- Enhanced the `setVideoZoomFactor` method in `ZLCustomCamera` to use the new implementation only if `cameraConfig.enableWideCameras` is true. Otherwise, it uses the original implementation.

## Benefits

- Flexibility: This feature allows users to take advantage of wide cameras, providing more options for capturing photos and videos.

- User Experience: Users can now capture wider shots, which is especially useful for landscape photography, group photos, and more.

## Non-Breaking Change
This change is non-breaking and does not affect existing functionality. The wide camera feature is disabled by default and can be enabled by setting the `enableWideCameras` parameter to true.

---

Please review the changes and let me know if there are any adjustments or additional features you would like to include. Thank you!