### PR TITLE
Add completion callback to cancel button in `ZLEditVideoViewController`

### DIFF
--- a/Sources/Edit/ZLEditVideoViewController.swift
+++ b/Sources/Edit/ZLEditVideoViewController.swift
@@ -268,7 +268,7 @@ public class ZLEditVideoViewController: UIViewController {
     }
     
     @objc private func cancelBtnClick() {
-        dismiss(animated: animateDismiss, completion: nil)
+        dismiss(animated: animateDismiss) { self.editFinishBlock?(nil) }
     }
     
     @objc private func doneBtnClick() {

--- a/Sources/Edit/ZLEditVideoViewController.swift
+++ b/Sources/Edit/ZLEditVideoViewController.swift
@@ -151,6 +151,8 @@ public class ZLEditVideoViewController: UIViewController {
     
     @objc public var editFinishBlock: ((URL?) -> Void)?
     
+    @objc public var cancelEditBlock: (() -> Void)?
+    
     override public var prefersStatusBarHidden: Bool {
         return true
     }
@@ -268,7 +270,9 @@ public class ZLEditVideoViewController: UIViewController {
     }
     
     @objc private func cancelBtnClick() {
-        dismiss(animated: animateDismiss) { self.editFinishBlock?(nil) }
+        dismiss(animated: animateDismiss) {
+            self.cancelEditBlock?()
+        }
     }
     
     @objc private func doneBtnClick() {


### PR DESCRIPTION
Hey @longitachi - I promised not to send any more PR in the near future, but I found something that can still be adjusted 😅
This tiny change adds a completion callback to the `cancelBtnClick` method in `ZLEditVideoViewController` to notify the developer when the cancel button is clicked. This ensures that the developer can perform any necessary cleanup or state updates when the user cancels the video editing.