### PR TITLE
feat(camera): add video stabilization support in custom camera

### DIFF
--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -1193,6 +1193,10 @@ open class ZLCustomCamera: UIViewController {
         } else {
             connection?.videoOrientation = cacheVideoOrientation
         }
+            
+        if let connection = connection, connection.isVideoStabilizationSupported {
+            connection.preferredVideoStabilizationMode = cameraConfig.videoStabilizationMode
+        }
         
         // 解决不同系统版本,因为录制视频编码导致安卓端无法播放的问题
         if #available(iOS 11.0, *),

--- a/Sources/General/ZLCameraConfiguration.swift
+++ b/Sources/General/ZLCameraConfiguration.swift
@@ -118,6 +118,9 @@ public class ZLCameraConfiguration: NSObject {
         }
     }
     
+    /// Video stabilization mode. Defaults to .off.
+    public var videoStabilizationMode: AVCaptureVideoStabilizationMode = .off
+    
     /// Video export format for recording video and editing video. Defaults to mov.
     public var videoExportType: ZLCameraConfiguration.VideoExportType = .mov
     
@@ -333,6 +336,12 @@ public extension ZLCameraConfiguration {
     @discardableResult
     func overlayView(_ value: UIView) -> ZLCameraConfiguration {
         overlayView = value
+        return self
+    }
+    
+    @discardableResult
+    func videoStabilizationMode(_ value: AVCaptureVideoStabilizationMode) -> ZLCameraConfiguration {
+        videoStabilizationMode = value
         return self
     }
 }


### PR DESCRIPTION
Hey @longitachi this is just a small PR that adds the ability to provide video stabilization mode, which is set to `.off` (it's also the framework's [default value](https://developer.apple.com/documentation/avfoundation/avcaptureconnection/preferredvideostabilizationmode/)) so it shouldn't be a breaking change. Thanks!