### PR TITLE
fix(camera): fix video recording with both torch-on and wide cameras

### DIFF
--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -638,6 +638,7 @@ open class ZLCustomCamera: UIViewController {
 
         if isWideCameraEnabled() {
             if let camera = findFirstDevice(ofTypes: extendedDeviceTypes, in: session) {
+                torchDevice = camera
                 return camera
             }
         }


### PR DESCRIPTION
Hey @longitachi, this is just a small fix for the wrong torch device selected with the wide camera feature on (and torch turned on).

Steps to replicate:
Run example app with:
```swift
.cameraConfiguration.enableWideCameras(true)
```
Open "Custom Camera" turn on the torch and try to record the video - it will fail (torch will remain turned on) with 1 frame video. This line in this PR should fix this issue (the torch device will be associated with the proper camera). Thanks!