### PR TITLE
fix: correct eraser misalignment after image cropping

### DIFF
--- a/Sources/Edit/ZLEditImageViewController.swift
+++ b/Sources/Edit/ZLEditImageViewController.swift
@@ -1332,7 +1332,10 @@ open class ZLEditImageViewController: UIViewController {
                 transform = transform.translatedBy(x: -drawingImageViewSize.height, y: 0)
             }
             transform = transform.concatenating(drawingImageView.transform)
-            eraserCircleView.center = point.applying(transform)
+            let transformedPoint = point.applying(transform)
+            // 将变换后的点转换到 containerView 的坐标系
+            let pointInContainerView = drawingImageView.convert(transformedPoint, to: containerView)
+            eraserCircleView.center = pointInContainerView
             
             var needDraw = false
             for path in drawPaths {


### PR DESCRIPTION
Hey, @longitachi , I made a small fix to address the issue of the eraser icon being misaligned after cropping an image. You can see the reproduction steps in my recording. Thanks!

https://github.com/user-attachments/assets/6faef932-158c-41bb-b052-1480662a49ba

