### PR TITLE
Update ZLCameraCell.swift

### DIFF
--- a/Sources/General/ZLCameraCell.swift
+++ b/Sources/General/ZLCameraCell.swift
@@ -119,8 +119,10 @@ class ZLCameraCell: UICollectionViewCell {
         previewLayer?.frame = contentView.layer.bounds
         previewLayer?.videoGravity = .resizeAspectFill
         contentView.layer.insertSublayer(previewLayer!, at: 0)
-        
-        session?.startRunning()
+
+        DispatchQueue.global(qos: .background).async {
+            self.session?.startRunning()
+        }
     }
     
     private func backCamera() -> AVCaptureDevice? {


### PR DESCRIPTION
fix: 主线程卡顿和线程警告。
当showCaptureImageOnTakePhotoBtn = true 的时候会卡主线程并有线程警告的问题。