### PR TITLE
feat: support for locked output orientation in custom camera

### DIFF
--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -783,7 +783,13 @@ open class ZLCustomCamera: UIViewController {
         cleanTimer()
         hideTipsLabel()
     }
-    
+
+    @objc private func autoStopRecording_timerFunc() {
+        if movieFileOutput?.isRecording == true {
+            finishRecord()
+        }
+    }
+
     private func startHideTipsLabelTimer() {
         cleanTimer()
         hideTipsTimer = Timer.scheduledTimer(timeInterval: 3, target: ZLWeakProxy(target: self), selector: #selector(hideTipsLabel_timerFunc), userInfo: nil, repeats: false)
@@ -1235,13 +1241,12 @@ open class ZLCustomCamera: UIViewController {
         if shouldScheduleStop {
             cleanAutoStopTimer() // Cancel any existing timer.
             autoStopTimer = Timer.scheduledTimer(
-                withTimeInterval: Double(cameraConfig.maxRecordDuration),
+                timeInterval: Double(cameraConfig.maxRecordDuration),
+                target: ZLWeakProxy(target: self),
+                selector: #selector(autoStopRecording_timerFunc),
+                userInfo: nil,
                 repeats: false
-            ) { [weak self] _ in // Schedule new timer for full duration.
-                if self?.movieFileOutput?.isRecording == true {
-                    self?.finishRecord()
-                }
-            }
+            )
         }
     }
     

--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -1431,7 +1431,7 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
             let duration = self.recordDurations.reduce(0, +)
 
             // 重置焦距
-            self.setVideoZoomFactor(1)
+            self.setVideoZoomFactor(self.isWideCameraEnabled() ? (self.videoInput?.device.defaultZoomFactor ?? 1) : 1)
             if duration < Double(self.cameraConfig.minRecordDuration) {
                 showAlertView(String(format: localLanguageTextValue(.minRecordTimeTips), self.cameraConfig.minRecordDuration), self)
                 self.recordURLs.forEach { try? FileManager.default.removeItem(at: $0) }

--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -459,7 +459,7 @@ open class ZLCustomCamera: UIViewController {
                 largeCircleView.addGestureRecognizer(longGes)
                 takePictureTap?.require(toFail: longGes)
                 recordLongGes = longGes
-                
+
                 let panGes = UIPanGestureRecognizer(target: self, action: #selector(adjustCameraFocus(_:)))
                 panGes.delegate = self
                 panGes.maximumNumberOfTouches = 1
@@ -584,7 +584,7 @@ open class ZLCustomCamera: UIViewController {
             self.session.startRunning()
         }
     }
-    
+
     private func setInitialZoomFactor(for device: AVCaptureDevice) {
         guard isWideCameraEnabled() else { return }
         do {
@@ -633,20 +633,20 @@ open class ZLCustomCamera: UIViewController {
         } else {
             allDeviceTypes = deviceTypes
         }
-        
+
         let session = AVCaptureDevice.DiscoverySession(
             deviceTypes: allDeviceTypes,
             mediaType: .video,
             position: position
         )
-        
+
         if isWideCameraEnabled() {
             if let camera = findFirstDevice(ofTypes: extendedDeviceTypes, in: session) {
                 torchDevice = camera
                 return camera
             }
         }
-        
+
         for device in session.devices {
             if device.position == position {
                 return device
@@ -1252,7 +1252,7 @@ open class ZLCustomCamera: UIViewController {
         guard let movieFileOutput = movieFileOutput else {
             return
         }
-        
+
         guard movieFileOutput.isRecording else {
             return
         }
@@ -1455,7 +1455,7 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
                         self?.videoURL = nil
                         showAlertView(error.localizedDescription, self)
                     }
-                    
+
                     self?.recordURLs.forEach { try? FileManager.default.removeItem(at: $0) }
                     self?.recordURLs.removeAll()
                     self?.recordDurations.removeAll()

--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -40,11 +40,11 @@ open class ZLCustomCamera: UIViewController {
         static let cameraBtnNormalColor: UIColor = .white
         static let cameraBtnRecodingBorderColor: UIColor = .white.withAlphaComponent(0.8)
     }
-
+    
     @objc public var takeDoneBlock: ((UIImage?, URL?) -> Void)?
-
+    
     @objc public var cancelBlock: (() -> Void)?
-
+    
     public lazy var tipsLabel: UILabel = {
         let label = UILabel()
         label.font = .zl.font(ofSize: 14)
@@ -55,15 +55,15 @@ open class ZLCustomCamera: UIViewController {
         label.alpha = 0
         return label
     }()
-
+    
     public lazy var bottomView = UIView()
-
+    
     public lazy var largeCircleView: UIView = {
         let view = UIView()
         view.layer.addSublayer(borderLayer)
         return view
     }()
-
+    
     public lazy var smallCircleView: UIView = {
         let view = UIView()
         view.layer.masksToBounds = true
@@ -72,11 +72,11 @@ open class ZLCustomCamera: UIViewController {
         view.backgroundColor = ZLCustomCamera.Layout.cameraBtnNormalColor
         return view
     }()
-
+    
     public lazy var borderLayer: CAShapeLayer = {
         let animateLayerRadius = ZLCustomCamera.Layout.largeCircleRadius
         let path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: animateLayerRadius, height: animateLayerRadius), cornerRadius: animateLayerRadius / 2)
-
+        
         let layer = CAShapeLayer()
         layer.path = path.cgPath
         layer.strokeColor = ZLCustomCamera.Layout.cameraBtnNormalColor.cgColor
@@ -84,11 +84,11 @@ open class ZLCustomCamera: UIViewController {
         layer.lineWidth = ZLCustomCamera.Layout.borderLayerWidth
         return layer
     }()
-
+    
     public lazy var animateLayer: CAShapeLayer = {
         let animateLayerRadius = ZLCustomCamera.Layout.largeCircleRadius
         let path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: animateLayerRadius, height: animateLayerRadius), cornerRadius: animateLayerRadius / 2)
-
+        
         let layer = CAShapeLayer()
         layer.path = path.cgPath
         layer.strokeColor = UIColor.zl.cameraRecodeProgressColor.cgColor
@@ -97,7 +97,7 @@ open class ZLCustomCamera: UIViewController {
         layer.lineCap = .round
         return layer
     }()
-
+    
     public lazy var retakeBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_retake"), for: .normal)
@@ -107,7 +107,7 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-
+    
     public lazy var doneBtn: UIButton = {
         let btn = UIButton(type: .custom)
         btn.titleLabel?.font = ZLLayout.bottomToolTitleFont
@@ -120,7 +120,7 @@ open class ZLCustomCamera: UIViewController {
         btn.layer.cornerRadius = ZLLayout.bottomToolBtnCornerRadius
         return btn
     }()
-
+    
     public lazy var dismissBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_camera_close"), for: .normal)
@@ -129,7 +129,7 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-
+    
     public lazy var flashBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_flash_off"), for: .normal)
@@ -139,10 +139,10 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-
+    
     public lazy var switchCameraBtn: ZLEnlargeButton = {
         let cameraCount = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: .unspecified).devices.count
-
+        
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_toggle_camera"), for: .normal)
         btn.addTarget(self, action: #selector(switchCameraBtnClick), for: .touchUpInside)
@@ -151,7 +151,7 @@ open class ZLCustomCamera: UIViewController {
         btn.isHidden = !cameraConfig.allowSwitchCamera || cameraCount <= 1
         return btn
     }()
-
+    
     public lazy var focusCursorView: UIImageView = {
         let view = UIImageView(image: .zl.getImage("zl_focus"))
         view.contentMode = .scaleAspectFit
@@ -160,7 +160,7 @@ open class ZLCustomCamera: UIViewController {
         view.alpha = 0
         return view
     }()
-
+    
     public lazy var takedImageView: UIImageView = {
         let view = UIImageView()
         view.backgroundColor = .black
@@ -168,119 +168,119 @@ open class ZLCustomCamera: UIViewController {
         view.contentMode = .scaleAspectFit
         return view
     }()
-
+    
     private var hideTipsTimer: Timer?
-
+    
     private var takedImage: UIImage?
-
+    
     private var videoURL: URL?
-
+    
     private var motionManager: CMMotionManager?
-
+    
     private var orientation: AVCaptureVideoOrientation = .portrait
-
+    
     private var torchDevice = AVCaptureDevice.default(for: .video)
-
+    
     private let sessionQueue = DispatchQueue(label: "com.zl.camera.sessionQueue")
-
+    
     private let session = AVCaptureSession()
-
+    
     private var videoInput: AVCaptureDeviceInput?
-
+    
     private var imageOutput: AVCapturePhotoOutput?
-
+    
     private var movieFileOutput: AVCaptureMovieFileOutput?
-
+    
     private var previewLayer: AVCaptureVideoPreviewLayer?
-
+    
     private var recordVideoPlayerLayer: AVPlayerLayer?
-
+    
     private var cameraConfigureFinish = false
-
+    
     private var shouldLayout = true
-
+    
     private var dragStart = false
-
+    
     private var viewDidAppearCount = 0
-
+    
     private var restartRecordAfterSwitchCamera = false
-
+    
     private var isSwitchingCamera = false
-
+    
     private var cacheVideoOrientation: AVCaptureVideoOrientation = .portrait
-
+    
     private var recordURLs: [URL] = []
-
+    
     private var recordDurations: [Double] = []
-
+    
     private var microPhontIsAvailable = true
-
+    
     private lazy var focusCursorTapGes: UITapGestureRecognizer = {
         let tap = UITapGestureRecognizer()
         tap.addTarget(self, action: #selector(adjustFocusPoint))
         tap.delegate = self
         return tap
     }()
-
+    
     private var cameraFocusPanGes: UIPanGestureRecognizer?
-
+    
     private var recordLongGes: UILongPressGestureRecognizer?
-
+    
     /// 是否正在调整焦距
     private var isAdjustingFocusPoint = false
-
+    
     /// 是否正在拍照
     private var isTakingPicture = false
-
+    
     private var showFlashBtn = true {
         didSet {
             flashBtn.isHidden = !showFlashBtn
         }
     }
-
+    
     private var shouldUseTapToRecord: Bool {
         cameraConfig.tapToRecordVideo && !cameraConfig.allowTakePhoto
     }
-
+    
     private lazy var cameraConfig = ZLPhotoConfiguration.default().cameraConfiguration
-
+    
     /// Automatically stops recording video after maxRecordDuration on tapToRecordVideo.
     private var autoStopTimer: Timer?
-
+    
     // 仅支持竖屏
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         deviceIsiPhone() ? .portrait : .all
     }
-
+    
     override public var prefersStatusBarHidden: Bool {
         return true
     }
-
+    
     deinit {
         zl_debugPrint("ZLCustomCamera deinit")
         cleanAutoStopTimer()
         cleanTimer()
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
-
+    
     @objc public init() {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
     }
-
+    
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
+    
     override open func viewDidLoad() {
         super.viewDidLoad()
-
+        
         setupUI()
         if !UIImagePickerController.isSourceTypeAvailable(.camera) {
             return
         }
-
+        
         AVCaptureDevice.requestAccess(for: .video) { videoGranted in
             guard videoGranted else {
                 ZLMainAsync(after: 1) {
@@ -288,12 +288,12 @@ open class ZLCustomCamera: UIViewController {
                 }
                 return
             }
-
+            
             guard self.cameraConfig.allowRecordVideo else {
                 self.addNotification()
                 return
             }
-
+            
             AVCaptureDevice.requestAccess(for: .audio) { audioGranted in
                 self.addNotification()
                 if !audioGranted {
@@ -303,7 +303,7 @@ open class ZLCustomCamera: UIViewController {
                 }
             }
         }
-
+        
         if cameraConfig.allowRecordVideo {
             do {
                 try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .videoRecording, options: .duckOthers)
@@ -316,15 +316,15 @@ open class ZLCustomCamera: UIViewController {
                 }
             }
         }
-
+        
         setupCamera()
     }
-
+    
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         observerDeviceMotion()
     }
-
+    
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if !UIImagePickerController.isSourceTypeAvailable(.camera) {
@@ -343,70 +343,70 @@ open class ZLCustomCamera: UIViewController {
         }
         viewDidAppearCount += 1
     }
-
+    
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         motionManager?.stopDeviceMotionUpdates()
         motionManager = nil
     }
-
+    
     override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         guard session.isRunning else { return }
-
+        
         sessionQueue.async {
             self.session.stopRunning()
         }
     }
-
+    
     override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         shouldLayout = true
     }
-
+    
     override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         guard shouldLayout else { return }
         shouldLayout = false
-
+        
         var insets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         if #available(iOS 11.0, *) {
             insets = self.view.safeAreaInsets
         }
-
+        
         let cameraRatio: CGFloat = 16 / 9
         let layerH = min(view.zl.width * cameraRatio, view.zl.height)
-
+        
         let previewLayerY: CGFloat
         if isSmallScreen() {
             previewLayerY = deviceIsFringeScreen() ? min(94, view.zl.height - layerH) : 0
         } else {
             previewLayerY = 0
         }
-
+        
         let previewFrame = CGRect(x: 0, y: previewLayerY, width: view.bounds.width, height: layerH)
         previewLayer?.frame = previewFrame
         recordVideoPlayerLayer?.frame = previewFrame
         takedImageView.frame = previewFrame
         cameraConfig.overlayView?.frame = previewFrame // Layout custom overlay view.
-
+        
         dismissBtn.frame = CGRect(x: 20, y: 60, width: 30, height: 30)
         retakeBtn.frame = CGRect(x: 20, y: 60, width: 28, height: 28)
-
+        
         var bottomViewToBottomSpacing = view.zl.height - insets.bottom - ZLCustomCamera.Layout.bottomViewH
         if view.zl.height <= 812 {
             bottomViewToBottomSpacing -= deviceIsFringeScreen() ? 40 : 20
         }
-
+        
         bottomView.frame = CGRect(x: 0, y: bottomViewToBottomSpacing, width: view.bounds.width, height: ZLCustomCamera.Layout.bottomViewH)
         let largeCircleH = ZLCustomCamera.Layout.largeCircleRadius
         largeCircleView.frame = CGRect(x: (view.bounds.width - largeCircleH) / 2, y: (ZLCustomCamera.Layout.bottomViewH - largeCircleH) / 2, width: largeCircleH, height: largeCircleH)
         let smallCircleH = ZLCustomCamera.Layout.smallCircleRadius
         smallCircleView.frame = CGRect(x: (view.bounds.width - smallCircleH) / 2, y: (ZLCustomCamera.Layout.bottomViewH - smallCircleH) / 2, width: smallCircleH, height: smallCircleH)
-
+        
         flashBtn.frame = CGRect(x: 60, y: (ZLCustomCamera.Layout.bottomViewH - 25) / 2, width: 25, height: 25)
         switchCameraBtn.frame = CGRect(x: bottomView.zl.width - 60 - 25, y: flashBtn.zl.top, width: 25, height: 25)
-
+        
         let tipsTextHeight = (tipsLabel.text ?? " ").zl
             .boundingRect(
                 font: .zl.font(ofSize: 14),
@@ -414,7 +414,7 @@ open class ZLCustomCamera: UIViewController {
             )
             .height + 30
         tipsLabel.frame = CGRect(x: 10, y: bottomView.frame.minY - tipsTextHeight, width: view.bounds.width - 20, height: tipsTextHeight)
-
+        
         let doneBtnW = (doneBtn.currentTitle ?? "")
             .zl.boundingRect(
                 font: ZLLayout.bottomToolTitleFont,
@@ -424,25 +424,25 @@ open class ZLCustomCamera: UIViewController {
         let doneBtnY = view.bounds.height - 57 - insets.bottom
         doneBtn.frame = CGRect(x: view.bounds.width - doneBtnW - 20, y: doneBtnY, width: doneBtnW, height: ZLLayout.bottomToolBtnH)
     }
-
+    
     private func setupUI() {
         view.backgroundColor = .black
-
+        
         view.addSubview(dismissBtn)
         view.addSubview(takedImageView)
         view.addSubview(focusCursorView)
         view.addSubview(tipsLabel)
         view.addSubview(bottomView)
-
+        
         if let overlayView = cameraConfig.overlayView {
             view.addSubview(overlayView)  // Add custom overlay view.
         }
-
+        
         bottomView.addSubview(flashBtn)
         bottomView.addSubview(largeCircleView)
         bottomView.addSubview(smallCircleView)
         bottomView.addSubview(switchCameraBtn)
-
+        
         var takePictureTap: UITapGestureRecognizer?
         if cameraConfig.allowTakePhoto {
             takePictureTap = UITapGestureRecognizer(target: self, action: #selector(takePicture))
@@ -459,39 +459,39 @@ open class ZLCustomCamera: UIViewController {
                 largeCircleView.addGestureRecognizer(longGes)
                 takePictureTap?.require(toFail: longGes)
                 recordLongGes = longGes
-
+                
                 let panGes = UIPanGestureRecognizer(target: self, action: #selector(adjustCameraFocus(_:)))
                 panGes.delegate = self
                 panGes.maximumNumberOfTouches = 1
                 largeCircleView.addGestureRecognizer(panGes)
                 cameraFocusPanGes = panGes
             }
-
+            
             recordVideoPlayerLayer = AVPlayerLayer()
             recordVideoPlayerLayer?.backgroundColor = UIColor.black.cgColor
             recordVideoPlayerLayer?.videoGravity = .resizeAspect
             recordVideoPlayerLayer?.isHidden = true
             view.layer.insertSublayer(recordVideoPlayerLayer!, at: 0)
-
+            
             NotificationCenter.default.addObserver(self, selector: #selector(recordVideoPlayFinished), name: .AVPlayerItemDidPlayToEndTime, object: nil)
         }
-
+        
         view.addSubview(retakeBtn)
         view.addSubview(doneBtn)
-
+        
         // 预览layer
         previewLayer = AVCaptureVideoPreviewLayer(session: session)
         previewLayer?.videoGravity = .resizeAspectFill
         previewLayer?.opacity = 0
         view.layer.masksToBounds = true
         view.layer.insertSublayer(previewLayer!, at: 0)
-
+        
         view.addGestureRecognizer(focusCursorTapGes)
-
+        
         let pinchGes = UIPinchGestureRecognizer(target: self, action: #selector(pinchToAdjustCameraFocus(_:)))
         view.addGestureRecognizer(pinchGes)
     }
-
+    
     private func observerDeviceMotion() {
         if !Thread.isMainThread {
             ZLMainAsync {
@@ -501,7 +501,7 @@ open class ZLCustomCamera: UIViewController {
         }
         motionManager = CMMotionManager()
         motionManager?.deviceMotionUpdateInterval = 0.5
-
+        
         if motionManager?.isDeviceMotionAvailable == true {
             motionManager?.startDeviceMotionUpdates(to: .main, withHandler: { motion, _ in
                 if let motion = motion {
@@ -512,11 +512,11 @@ open class ZLCustomCamera: UIViewController {
             motionManager = nil
         }
     }
-
+    
     func handleDeviceMotion(_ motion: CMDeviceMotion) {
         let x = motion.gravity.x
         let y = motion.gravity.y
-
+        
         if abs(y) >= abs(x) || abs(x) < 0.45 {
             if y >= 0.45 {
                 orientation = .portraitUpsideDown
@@ -531,32 +531,32 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     private func setupCamera() {
         let cameraConfig = ZLPhotoConfiguration.default().cameraConfiguration
-
+        
         guard let camera = getCamera(position: cameraConfig.devicePosition.avDevicePosition) else { return }
         guard let input = try? AVCaptureDeviceInput(device: camera) else { return }
-
+        
         session.beginConfiguration()
-
+        
         // 相机画面输入流
         videoInput = input
-
+        
         refreshSessionPreset(device: camera)
-
+        
         let movieFileOutput = AVCaptureMovieFileOutput()
         // 解决视频录制超过10s没有声音的bug
         movieFileOutput.movieFragmentInterval = .invalid
         self.movieFileOutput = movieFileOutput
-
+        
         // 添加视频输入
         if let videoInput = videoInput, session.canAddInput(videoInput) {
             session.addInput(videoInput)
         }
         // 添加音频输入
         addAudioInput()
-
+        
         // 照片输出流
         let imageOutput = AVCapturePhotoOutput()
         self.imageOutput = imageOutput
@@ -567,24 +567,24 @@ open class ZLCustomCamera: UIViewController {
         if session.canAddOutput(movieFileOutput) {
             session.addOutput(movieFileOutput)
         }
-
+        
         // imageOutPut添加到session之后才能判断supportedFlashModes
         if !cameraConfig.showFlashSwitch || torchDevice?.hasFlash == false {
             ZLMainAsync {
                 self.showFlashBtn = false
             }
         }
-
+        
         session.commitConfiguration()
-
+        
         cameraConfigureFinish = true
-
+        
         sessionQueue.async {
             self.setInitialZoomFactor(for: camera)
             self.session.startRunning()
         }
     }
-
+    
     private func setInitialZoomFactor(for device: AVCaptureDevice) {
         guard isWideCameraEnabled() else { return }
         do {
@@ -595,7 +595,7 @@ open class ZLCustomCamera: UIViewController {
             zl_debugPrint("Failed to set initial zoom factor: \(error.localizedDescription)")
         }
     }
-
+    
     private func findFirstDevice(ofTypes types: [AVCaptureDevice.DeviceType], in session: AVCaptureDevice.DiscoverySession) -> AVCaptureDevice? {
         for type in types {
             if let device = session.devices.first(where: { $0.deviceType == type }) {
@@ -604,16 +604,16 @@ open class ZLCustomCamera: UIViewController {
         }
         return nil
     }
-
+    
     private func refreshSessionPreset(device: AVCaptureDevice) {
         func setSessionPreset(_ preset: AVCaptureSession.Preset) {
             guard session.sessionPreset != preset else {
                 return
             }
-
+            
             session.sessionPreset = preset
         }
-
+        
         let preset = cameraConfig.sessionPreset.avSessionPreset
         if device.supportsSessionPreset(preset), session.canSetSessionPreset(preset) {
             setSessionPreset(preset)
@@ -621,32 +621,32 @@ open class ZLCustomCamera: UIViewController {
             setSessionPreset(.photo)
         }
     }
-
+    
     private func getCamera(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
         let deviceTypes: [AVCaptureDevice.DeviceType] = [.builtInWideAngleCamera]
         var extendedDeviceTypes: [AVCaptureDevice.DeviceType] = []
         let allDeviceTypes: [AVCaptureDevice.DeviceType]
-
+        
         if #available(iOS 13.0, *), cameraConfig.enableWideCameras {
             extendedDeviceTypes = [.builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera]
             allDeviceTypes = deviceTypes + extendedDeviceTypes
         } else {
             allDeviceTypes = deviceTypes
         }
-
+        
         let session = AVCaptureDevice.DiscoverySession(
             deviceTypes: allDeviceTypes,
             mediaType: .video,
             position: position
         )
-
+        
         if isWideCameraEnabled() {
             if let camera = findFirstDevice(ofTypes: extendedDeviceTypes, in: session) {
                 torchDevice = camera
                 return camera
             }
         }
-
+        
         for device in session.devices {
             if device.position == position {
                 return device
@@ -654,24 +654,24 @@ open class ZLCustomCamera: UIViewController {
         }
         return nil
     }
-
+    
     private func getMicrophone() -> AVCaptureDevice? {
         return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInMicrophone], mediaType: .audio, position: .unspecified).devices.first
     }
-
+    
     private func addAudioInput() {
         guard cameraConfig.allowRecordVideo else { return }
-
+        
         // 音频输入流
         var audioInput: AVCaptureDeviceInput?
         if let microphone = getMicrophone() {
             audioInput = try? AVCaptureDeviceInput(device: microphone)
         }
-
+        
         guard microPhontIsAvailable, let ai = audioInput else { return }
-
+        
         removeAudioInput()
-
+        
         if session.isRunning {
             session.beginConfiguration()
         }
@@ -682,7 +682,7 @@ open class ZLCustomCamera: UIViewController {
             session.commitConfiguration()
         }
     }
-
+    
     private func removeAudioInput() {
         var audioInput: AVCaptureInput?
         for input in session.inputs {
@@ -691,7 +691,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
         guard let audioInput = audioInput else { return }
-
+        
         if session.isRunning {
             session.beginConfiguration()
         }
@@ -700,16 +700,16 @@ open class ZLCustomCamera: UIViewController {
             session.commitConfiguration()
         }
     }
-
+    
     private func addNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
-
+        
         if cameraConfig.allowRecordVideo {
             NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(handleAudioSessionInterruption), name: AVAudioSession.interruptionNotification, object: nil)
         }
     }
-
+    
     private func showNoMicrophoneAuthorityAlert() {
         let continueAction = ZLCustomAlertAction(title: localLanguageTextValue(.keepRecording), style: .default, handler: nil)
         let gotoSettingsAction = ZLCustomAlertAction(title: localLanguageTextValue(.gotoSettings), style: .tint) { _ in
@@ -722,13 +722,13 @@ open class ZLCustomCamera: UIViewController {
         }
         showAlertController(title: nil, message: String(format: localLanguageTextValue(.noMicrophoneAuthority), getAppName()), style: .alert, actions: [continueAction, gotoSettingsAction], sender: self)
     }
-
+    
     private func showAlertAndDismissAfterDoneAction(message: String, type: ZLNoAuthorityType?) {
         if let type, let customAlertWhenNoAuthority = ZLPhotoConfiguration.default().customAlertWhenNoAuthority {
             customAlertWhenNoAuthority(type)
             return
         }
-
+        
         let action = ZLCustomAlertAction(title: localLanguageTextValue(.done), style: .default) { [weak self] _ in
             self?.dismiss(animated: true) {
                 if let type {
@@ -738,7 +738,7 @@ open class ZLCustomCamera: UIViewController {
         }
         showAlertController(title: nil, message: message, style: .alert, actions: [action], sender: self)
     }
-
+    
     private func cameraUsageTipsText() -> String {
         if cameraConfig.allowTakePhoto, cameraConfig.allowRecordVideo {
             return localLanguageTextValue(.customCameraTips)
@@ -748,13 +748,13 @@ open class ZLCustomCamera: UIViewController {
             if shouldUseTapToRecord {
                 return localLanguageTextValue(.customCameraTapToRecordVideoTips)
             }
-
+            
             return localLanguageTextValue(.customCameraRecordVideoTips)
         } else {
             return ""
         }
     }
-
+    
     private func showTipsLabel(message: String, animated: Bool = true) {
         tipsLabel.layer.removeAllAnimations()
         tipsLabel.text = message
@@ -767,7 +767,7 @@ open class ZLCustomCamera: UIViewController {
         }
         startHideTipsLabelTimer()
     }
-
+    
     private func hideTipsLabel(animated: Bool = true) {
         tipsLabel.layer.removeAllAnimations()
         if animated {
@@ -778,23 +778,23 @@ open class ZLCustomCamera: UIViewController {
             tipsLabel.alpha = 0
         }
     }
-
+    
     @objc private func hideTipsLabel_timerFunc() {
         cleanTimer()
         hideTipsLabel()
     }
-
+    
     private func startHideTipsLabelTimer() {
         cleanTimer()
         hideTipsTimer = Timer.scheduledTimer(timeInterval: 3, target: ZLWeakProxy(target: self), selector: #selector(hideTipsLabel_timerFunc), userInfo: nil, repeats: false)
         RunLoop.current.add(hideTipsTimer!, forMode: .common)
     }
-
+    
     private func cleanTimer() {
         hideTipsTimer?.invalidate()
         hideTipsTimer = nil
     }
-
+    
     private func cleanAutoStopTimer() {
         autoStopTimer?.invalidate()
         autoStopTimer = nil
@@ -808,13 +808,13 @@ open class ZLCustomCamera: UIViewController {
             player.pause()
         }
     }
-
+    
     @objc private func appDidBecomeActive() {
         if videoURL != nil, let player = recordVideoPlayerLayer?.player {
             player.play()
         }
     }
-
+    
     @objc private func handleAudioSessionInterruption(_ notify: Notification) {
         guard recordVideoPlayerLayer?.isHidden == false, let player = recordVideoPlayerLayer?.player else {
             return
@@ -822,21 +822,21 @@ open class ZLCustomCamera: UIViewController {
         guard player.rate == 0 else {
             return
         }
-
+        
         let type = notify.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
         let option = notify.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt
         if type == AVAudioSession.InterruptionType.ended.rawValue, option == AVAudioSession.InterruptionOptions.shouldResume.rawValue {
             player.play()
         }
     }
-
+    
     @objc private func dismissBtnClick() {
         cleanAutoStopTimer()
         dismiss(animated: true) {
             self.cancelBlock?()
         }
     }
-
+    
     @objc private func retakeBtnClick() {
         sessionQueue.async {
             self.session.startRunning()
@@ -853,36 +853,36 @@ open class ZLCustomCamera: UIViewController {
             try? FileManager.default.removeItem(at: videoURL)
         }
     }
-
+    
     @objc private func flashBtnClick() {
         flashBtn.isSelected.toggle()
     }
-
+    
     @objc private func switchCameraBtnClick() {
         guard !restartRecordAfterSwitchCamera, !isSwitchingCamera else {
             return
         }
-
+        
         guard let videoInput, let movieFileOutput else {
             return
         }
-
+        
         if movieFileOutput.isRecording {
             let pauseTime = animateLayer.convertTime(CACurrentMediaTime(), from: nil)
             animateLayer.speed = 0
             animateLayer.timeOffset = pauseTime
             restartRecordAfterSwitchCamera = true
         }
-
+        
         isSwitchingCamera = true
         sessionQueue.async {
             do {
                 defer {
                     self.isSwitchingCamera = false
                 }
-
+                
                 let currInput = videoInput
-
+                
                 var newVideoInput: AVCaptureDeviceInput?
                 if currInput.device.position == .back, let front = self.getCamera(position: .front) {
                     newVideoInput = try AVCaptureDeviceInput(device: front)
@@ -891,14 +891,14 @@ open class ZLCustomCamera: UIViewController {
                 } else {
                     return
                 }
-
+                
                 if let newVideoInput {
                     self.session.beginConfiguration()
-
+                    
                     self.refreshSessionPreset(device: newVideoInput.device)
-
+                    
                     self.session.removeInput(currInput)
-
+                    
                     if self.session.canAddInput(newVideoInput) {
                         self.session.addInput(newVideoInput)
                         self.videoInput = newVideoInput
@@ -906,7 +906,7 @@ open class ZLCustomCamera: UIViewController {
                         self.refreshSessionPreset(device: currInput.device)
                         self.session.addInput(currInput)
                     }
-
+                    
                     self.setInitialZoomFactor(for: newVideoInput.device)
                     self.session.commitConfiguration()
                 }
@@ -915,24 +915,24 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     private func canEditImage() -> Bool {
         let config = ZLPhotoConfiguration.default()
-
+        
         guard config.allowEditImage else {
             return false
         }
-
+        
         // 如果满足如下条件，则会在拍照完成后，返回相册界面直接进入编辑界面，这里就不在编辑
         let editAfterSelect = config.editAfterSelectThumbnailImage && config.maxSelectCount == 1
         return !editAfterSelect
     }
-
+    
     @objc private func editImage() {
         guard let takedImage = takedImage, canEditImage() else {
             return
         }
-
+        
         ZLEditImageViewController.showEditImageVC(parentVC: self, image: takedImage) { [weak self] in
             self?.retakeBtnClick()
         } completion: { [weak self] editImage, _ in
@@ -941,7 +941,7 @@ open class ZLCustomCamera: UIViewController {
             self?.doneBtnClick()
         }
     }
-
+    
     @objc private func doneBtnClick() {
         recordVideoPlayerLayer?.player?.pause()
         // 置为nil会导致卡顿，先注释，不影响内存释放
@@ -950,7 +950,7 @@ open class ZLCustomCamera: UIViewController {
             self.takeDoneBlock?(self.takedImage, self.videoURL)
         }
     }
-
+    
     // 点击拍照
     @objc private func takePicture() {
         guard ZLPhotoManager.hasCameraAuthority(), !isTakingPicture else {
@@ -963,9 +963,9 @@ open class ZLCustomCamera: UIViewController {
             showAlertAndDismissAfterDoneAction(message: localLanguageTextValue(.cameraUnavailable), type: .camera)
             return
         }
-
+        
         isTakingPicture = true
-
+        
         let connection = imageOutput.connection(with: .video)
         connection?.videoOrientation = cameraConfig.lockedOutputOrientation ?? orientation
         if videoInput?.device.position == .front, connection?.isVideoMirroringSupported == true {
@@ -977,10 +977,10 @@ open class ZLCustomCamera: UIViewController {
         } else {
             setting.flashMode = .off
         }
-
+        
         imageOutput.capturePhoto(with: setting, delegate: self)
     }
-
+    
     // 长按录像
     @objc private func longPressAction(_ longGes: UILongPressGestureRecognizer) {
         if longGes.state == .began {
@@ -992,11 +992,11 @@ open class ZLCustomCamera: UIViewController {
             finishRecord()
         }
     }
-
+    
     @objc private func tapToRecordAction(_ tap: UITapGestureRecognizer) {
         movieFileOutput?.isRecording == true ? finishRecord() : startRecord(shouldScheduleStop: true)
     }
-
+    
     // 调整焦点
     @objc private func adjustFocusPoint(_ tap: UITapGestureRecognizer) {
         guard session.isRunning, !isAdjustingFocusPoint else {
@@ -1008,10 +1008,10 @@ open class ZLCustomCamera: UIViewController {
         }
         setFocusCusor(point: point)
     }
-
+    
     private func setFocusCusor(point: CGPoint) {
         animateFocusCursor(point: point)
-
+        
         // UI坐标转换为摄像头坐标
         let cameraPoint = previewLayer?.captureDevicePointConverted(fromLayerPoint: point) ?? view.center
         focusCamera(
@@ -1020,12 +1020,12 @@ open class ZLCustomCamera: UIViewController {
             point: cameraPoint
         )
     }
-
+    
     private func animateFocusCursor(point: CGPoint) {
         isAdjustingFocusPoint = true
         focusCursorView.center = point
         focusCursorView.alpha = 1
-
+        
         let scaleAnimation = ZLAnimationUtils.animation(type: .scale, fromValue: 2, toValue: 1, duration: 0.25)
         let fadeShowAnimation = ZLAnimationUtils.animation(type: .fade, fromValue: 0, toValue: 1, duration: 0.25)
         let fadeDismissAnimation = ZLAnimationUtils.animation(type: .fade, fromValue: 1, toValue: 0, duration: 0.25)
@@ -1038,12 +1038,12 @@ open class ZLCustomCamera: UIViewController {
         group.isRemovedOnCompletion = false
         focusCursorView.layer.add(group, forKey: nil)
     }
-
+    
     // 调整焦距
     @objc private func adjustCameraFocus(_ pan: UIPanGestureRecognizer) {
         let convertRect = bottomView.convert(largeCircleView.frame, to: view)
         let point = pan.location(in: view)
-
+        
         if pan.state == .began {
             dragStart = true
             startRecord()
@@ -1063,19 +1063,19 @@ open class ZLCustomCamera: UIViewController {
             finishRecord()
         }
     }
-
+    
     @objc private func pinchToAdjustCameraFocus(_ pinch: UIPinchGestureRecognizer) {
         guard let device = videoInput?.device else {
             return
         }
-
+        
         var zoomFactor = device.videoZoomFactor * pinch.scale
         zoomFactor = max(1, min(zoomFactor, getMaxZoomFactor()))
         setVideoZoomFactor(zoomFactor)
-
+        
         pinch.scale = 1
     }
-
+    
     private func isWideCameraEnabled() -> Bool {
         if #available(iOS 13.0, *) {
             return cameraConfig.enableWideCameras
@@ -1083,7 +1083,7 @@ open class ZLCustomCamera: UIViewController {
             return false
         }
     }
-
+    
     private func getMaxZoomFactor() -> CGFloat {
         guard let device = videoInput?.device else {
             return 1
@@ -1095,7 +1095,7 @@ open class ZLCustomCamera: UIViewController {
             return min(15, device.activeFormat.videoMaxZoomFactor)
         }
     }
-
+    
     private func setVideoZoomFactor(_ zoomFactor: CGFloat) {
         guard let device = videoInput?.device else {
             return
@@ -1114,15 +1114,15 @@ open class ZLCustomCamera: UIViewController {
             zl_debugPrint("调整焦距失败 \(error.localizedDescription)")
         }
     }
-
+    
     private func focusCamera(mode: AVCaptureDevice.FocusMode, exposureMode: AVCaptureDevice.ExposureMode, point: CGPoint) {
         do {
             guard let device = videoInput?.device else {
                 return
             }
-
+            
             try device.lockForConfiguration()
-
+            
             if device.isFocusModeSupported(mode) {
                 device.focusMode = mode
             }
@@ -1135,13 +1135,13 @@ open class ZLCustomCamera: UIViewController {
             if device.isExposurePointOfInterestSupported {
                 device.exposurePointOfInterest = point
             }
-
+            
             device.unlockForConfiguration()
         } catch {
             zl_debugPrint("相机聚焦设置失败 \(error.localizedDescription)")
         }
     }
-
+    
     // 打开手电筒
     private func openTorch() {
         guard flashBtn.isSelected,
@@ -1149,7 +1149,7 @@ open class ZLCustomCamera: UIViewController {
               torchDevice?.torchMode == .off else {
             return
         }
-
+        
         sessionQueue.async {
             do {
                 try self.torchDevice?.lockForConfiguration()
@@ -1160,7 +1160,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     // 关闭手电筒
     private func closeTorch() {
         guard flashBtn.isSelected,
@@ -1168,7 +1168,7 @@ open class ZLCustomCamera: UIViewController {
               torchDevice?.torchMode == .on else {
             return
         }
-
+        
         sessionQueue.async {
             do {
                 try self.torchDevice?.lockForConfiguration()
@@ -1179,24 +1179,24 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     private func startRecord(shouldScheduleStop: Bool = false) {
         guard let movieFileOutput = movieFileOutput else {
             return
         }
-
+        
         guard !movieFileOutput.isRecording else {
             return
         }
-
+        
         guard session.outputs.contains(movieFileOutput) else {
             showAlertAndDismissAfterDoneAction(message: localLanguageTextValue(.cameraUnavailable), type: .camera)
             return
         }
-
+        
         dismissBtn.isHidden = true
         flashBtn.isHidden = true
-
+        
         let connection = movieFileOutput.connection(with: .video)
         connection?.videoScaleAndCropFactor = 1
         if !restartRecordAfterSwitchCamera {
@@ -1206,11 +1206,11 @@ open class ZLCustomCamera: UIViewController {
         } else {
             connection?.videoOrientation = cacheVideoOrientation
         }
-
+        
         if let connection = connection, connection.isVideoStabilizationSupported {
             connection.preferredVideoStabilizationMode = cameraConfig.videoStabilizationMode
         }
-
+        
         // 解决不同系统版本,因为录制视频编码导致安卓端无法播放的问题
         if #available(iOS 11.0, *),
            movieFileOutput.availableVideoCodecTypes.contains(cameraConfig.videoCodecType),
@@ -1228,10 +1228,10 @@ open class ZLCustomCamera: UIViewController {
         } else {
             openTorch()
         }
-
+        
         let url = URL(fileURLWithPath: ZLVideoManager.getVideoExportFilePath())
         movieFileOutput.startRecording(to: url, recordingDelegate: self)
-
+        
         if shouldScheduleStop {
             cleanAutoStopTimer() // Cancel any existing timer.
             autoStopTimer = Timer.scheduledTimer(
@@ -1244,22 +1244,22 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     private func finishRecord() {
         closeTorch()
         restartRecordAfterSwitchCamera = false
-
+        
         guard let movieFileOutput = movieFileOutput else {
             return
         }
-
+        
         guard movieFileOutput.isRecording else {
             return
         }
-
+        
         movieFileOutput.stopRecording()
     }
-
+    
     private func startRecordAnimation() {
         UIView.animate(withDuration: 0.1, animations: {
             self.largeCircleView.layer.transform = CATransform3DScale(CATransform3DIdentity, ZLCustomCamera.Layout.largeCircleRecordScale, ZLCustomCamera.Layout.largeCircleRecordScale, 1)
@@ -1279,7 +1279,7 @@ open class ZLCustomCamera: UIViewController {
             self.animateLayer.add(animation, forKey: nil)
         }
     }
-
+    
     private func stopRecordAnimation() {
         ZLMainAsync {
             self.smallCircleView.backgroundColor = ZLCustomCamera.Layout.cameraBtnNormalColor
@@ -1294,7 +1294,7 @@ open class ZLCustomCamera: UIViewController {
             self.smallCircleView.transform = .identity
         }
     }
-
+    
     private func resetSubViewStatus() {
         ZLMainAsync {
             if self.session.isRunning {
@@ -1321,7 +1321,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-
+    
     private func playRecordVideo(fileURL: URL) {
         recordVideoPlayerLayer?.isHidden = false
         cameraConfig.overlayView?.isHidden = true
@@ -1330,7 +1330,7 @@ open class ZLCustomCamera: UIViewController {
         recordVideoPlayerLayer?.player = player
         player.play()
     }
-
+    
     @objc private func recordVideoPlayFinished() {
         recordVideoPlayerLayer?.player?.seek(to: .zero)
         recordVideoPlayerLayer?.player?.play()
@@ -1344,19 +1344,19 @@ extension ZLCustomCamera: AVCapturePhotoCaptureDelegate {
             self.previewLayer?.add(animation, forKey: nil)
         }
     }
-
+    
     public func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?, previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?, resolvedSettings: AVCaptureResolvedPhotoSettings, bracketSettings: AVCaptureBracketedStillImageSettings?, error: Error?) {
         cameraConfig.overlayView?.isHidden = true
         ZLMainAsync {
             defer {
                 self.isTakingPicture = false
             }
-
+            
             if photoSampleBuffer == nil || error != nil {
                 zl_debugPrint("拍照失败 \(error?.localizedDescription ?? "")")
                 return
             }
-
+            
             if let data = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: photoSampleBuffer!, previewPhotoSampleBuffer: previewPhotoSampleBuffer) {
                 self.sessionQueue.async {
                     self.session.stopRunning()
@@ -1383,7 +1383,7 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
             finishRecord()
             return
         }
-
+        
         if restartRecordAfterSwitchCamera {
             restartRecordAfterSwitchCamera = false
             ZLMainAsync {
@@ -1400,36 +1400,36 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
             }
         }
     }
-
+    
     public func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
         ZLMainAsync {
             self.recordURLs.append(outputFileURL)
             self.recordDurations.append(output.recordedDuration.seconds)
-
+            
             if self.restartRecordAfterSwitchCamera {
                 self.startRecord()
                 return
             }
-
+            
             self.finishRecordAndMergeVideo()
         }
     }
-
+    
     private func finishRecordAndMergeVideo() {
         ZLMainAsync {
             self.stopRecordAnimation()
             self.cleanAutoStopTimer() // Cancel timer when recording finishes.
-
+            
             defer {
                 self.resetSubViewStatus()
             }
-
+            
             guard !self.recordURLs.isEmpty else {
                 return
             }
-
+            
             let duration = self.recordDurations.reduce(0, +)
-
+            
             // 重置焦距
             self.setVideoZoomFactor(self.isWideCameraEnabled() ? (self.videoInput?.device.defaultZoomFactor ?? 1) : 1)
             if duration < Double(self.cameraConfig.minRecordDuration) {
@@ -1439,15 +1439,15 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
                 self.recordDurations.removeAll()
                 return
             }
-
+            
             self.session.stopRunning()
-
+            
             // 拼接视频
             if self.recordURLs.count > 1 {
                 let hud = ZLProgressHUD.show(toast: .processing)
                 ZLVideoManager.mergeVideos(fileURLs: self.recordURLs) { [weak self] url, error in
                     hud.hide()
-
+                    
                     if let url = url, error == nil {
                         self?.videoURL = url
                         self?.playRecordVideo(fileURL: url)
@@ -1455,7 +1455,7 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
                         self?.videoURL = nil
                         showAlertView(error.localizedDescription, self)
                     }
-
+                    
                     self?.recordURLs.forEach { try? FileManager.default.removeItem(at: $0) }
                     self?.recordURLs.removeAll()
                     self?.recordDurations.removeAll()
@@ -1486,12 +1486,12 @@ extension ZLCustomCamera: CAAnimationDelegate {
 extension ZLCustomCamera: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         let gesTuples: [(UIGestureRecognizer?, UIGestureRecognizer?)] = [(recordLongGes, cameraFocusPanGes), (recordLongGes, focusCursorTapGes), (cameraFocusPanGes, focusCursorTapGes)]
-
+        
         let result = gesTuples.map { ges1, ges2 in
             (ges1 == gestureRecognizer && ges2 == otherGestureRecognizer) ||
                 (ges2 == otherGestureRecognizer && ges1 == gestureRecognizer)
         }.filter { $0 == true }
-
+        
         return !result.isEmpty
     }
 }

--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -957,7 +957,7 @@ open class ZLCustomCamera: UIViewController {
         isTakingPicture = true
         
         let connection = imageOutput.connection(with: .video)
-        connection?.videoOrientation = orientation
+        connection?.videoOrientation = cameraConfig.lockedOutputOrientation ?? orientation
         if videoInput?.device.position == .front, connection?.isVideoMirroringSupported == true {
             connection?.isVideoMirrored = ZLPhotoConfiguration.default().cameraConfiguration.isVideoMirrored
         }
@@ -1190,8 +1190,9 @@ open class ZLCustomCamera: UIViewController {
         let connection = movieFileOutput.connection(with: .video)
         connection?.videoScaleAndCropFactor = 1
         if !restartRecordAfterSwitchCamera {
-            connection?.videoOrientation = orientation
-            cacheVideoOrientation = orientation
+            let setOrientation = cameraConfig.lockedOutputOrientation ?? orientation
+            connection?.videoOrientation = setOrientation
+            cacheVideoOrientation = setOrientation
         } else {
             connection?.videoOrientation = cacheVideoOrientation
         }

--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -40,11 +40,11 @@ open class ZLCustomCamera: UIViewController {
         static let cameraBtnNormalColor: UIColor = .white
         static let cameraBtnRecodingBorderColor: UIColor = .white.withAlphaComponent(0.8)
     }
-    
+
     @objc public var takeDoneBlock: ((UIImage?, URL?) -> Void)?
-    
+
     @objc public var cancelBlock: (() -> Void)?
-    
+
     public lazy var tipsLabel: UILabel = {
         let label = UILabel()
         label.font = .zl.font(ofSize: 14)
@@ -55,15 +55,15 @@ open class ZLCustomCamera: UIViewController {
         label.alpha = 0
         return label
     }()
-    
+
     public lazy var bottomView = UIView()
-    
+
     public lazy var largeCircleView: UIView = {
         let view = UIView()
         view.layer.addSublayer(borderLayer)
         return view
     }()
-    
+
     public lazy var smallCircleView: UIView = {
         let view = UIView()
         view.layer.masksToBounds = true
@@ -72,11 +72,11 @@ open class ZLCustomCamera: UIViewController {
         view.backgroundColor = ZLCustomCamera.Layout.cameraBtnNormalColor
         return view
     }()
-    
+
     public lazy var borderLayer: CAShapeLayer = {
         let animateLayerRadius = ZLCustomCamera.Layout.largeCircleRadius
         let path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: animateLayerRadius, height: animateLayerRadius), cornerRadius: animateLayerRadius / 2)
-        
+
         let layer = CAShapeLayer()
         layer.path = path.cgPath
         layer.strokeColor = ZLCustomCamera.Layout.cameraBtnNormalColor.cgColor
@@ -84,11 +84,11 @@ open class ZLCustomCamera: UIViewController {
         layer.lineWidth = ZLCustomCamera.Layout.borderLayerWidth
         return layer
     }()
-    
+
     public lazy var animateLayer: CAShapeLayer = {
         let animateLayerRadius = ZLCustomCamera.Layout.largeCircleRadius
         let path = UIBezierPath(roundedRect: CGRect(x: 0, y: 0, width: animateLayerRadius, height: animateLayerRadius), cornerRadius: animateLayerRadius / 2)
-        
+
         let layer = CAShapeLayer()
         layer.path = path.cgPath
         layer.strokeColor = UIColor.zl.cameraRecodeProgressColor.cgColor
@@ -97,7 +97,7 @@ open class ZLCustomCamera: UIViewController {
         layer.lineCap = .round
         return layer
     }()
-    
+
     public lazy var retakeBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_retake"), for: .normal)
@@ -107,7 +107,7 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-    
+
     public lazy var doneBtn: UIButton = {
         let btn = UIButton(type: .custom)
         btn.titleLabel?.font = ZLLayout.bottomToolTitleFont
@@ -120,7 +120,7 @@ open class ZLCustomCamera: UIViewController {
         btn.layer.cornerRadius = ZLLayout.bottomToolBtnCornerRadius
         return btn
     }()
-    
+
     public lazy var dismissBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_camera_close"), for: .normal)
@@ -129,7 +129,7 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-    
+
     public lazy var flashBtn: ZLEnlargeButton = {
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_flash_off"), for: .normal)
@@ -139,10 +139,10 @@ open class ZLCustomCamera: UIViewController {
         btn.enlargeInset = 30
         return btn
     }()
-    
+
     public lazy var switchCameraBtn: ZLEnlargeButton = {
         let cameraCount = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera], mediaType: .video, position: .unspecified).devices.count
-        
+
         let btn = ZLEnlargeButton(type: .custom)
         btn.setImage(.zl.getImage("zl_toggle_camera"), for: .normal)
         btn.addTarget(self, action: #selector(switchCameraBtnClick), for: .touchUpInside)
@@ -151,7 +151,7 @@ open class ZLCustomCamera: UIViewController {
         btn.isHidden = !cameraConfig.allowSwitchCamera || cameraCount <= 1
         return btn
     }()
-    
+
     public lazy var focusCursorView: UIImageView = {
         let view = UIImageView(image: .zl.getImage("zl_focus"))
         view.contentMode = .scaleAspectFit
@@ -160,7 +160,7 @@ open class ZLCustomCamera: UIViewController {
         view.alpha = 0
         return view
     }()
-    
+
     public lazy var takedImageView: UIImageView = {
         let view = UIImageView()
         view.backgroundColor = .black
@@ -168,115 +168,119 @@ open class ZLCustomCamera: UIViewController {
         view.contentMode = .scaleAspectFit
         return view
     }()
-    
+
     private var hideTipsTimer: Timer?
-    
+
     private var takedImage: UIImage?
-    
+
     private var videoURL: URL?
-    
+
     private var motionManager: CMMotionManager?
-    
+
     private var orientation: AVCaptureVideoOrientation = .portrait
-    
+
     private var torchDevice = AVCaptureDevice.default(for: .video)
-    
+
     private let sessionQueue = DispatchQueue(label: "com.zl.camera.sessionQueue")
-    
+
     private let session = AVCaptureSession()
-    
+
     private var videoInput: AVCaptureDeviceInput?
-    
+
     private var imageOutput: AVCapturePhotoOutput?
-    
+
     private var movieFileOutput: AVCaptureMovieFileOutput?
-    
+
     private var previewLayer: AVCaptureVideoPreviewLayer?
-    
+
     private var recordVideoPlayerLayer: AVPlayerLayer?
-    
+
     private var cameraConfigureFinish = false
-    
+
     private var shouldLayout = true
-    
+
     private var dragStart = false
-    
+
     private var viewDidAppearCount = 0
-    
+
     private var restartRecordAfterSwitchCamera = false
-    
+
     private var isSwitchingCamera = false
-    
+
     private var cacheVideoOrientation: AVCaptureVideoOrientation = .portrait
-    
+
     private var recordURLs: [URL] = []
-    
+
     private var recordDurations: [Double] = []
-    
+
     private var microPhontIsAvailable = true
-    
+
     private lazy var focusCursorTapGes: UITapGestureRecognizer = {
         let tap = UITapGestureRecognizer()
         tap.addTarget(self, action: #selector(adjustFocusPoint))
         tap.delegate = self
         return tap
     }()
-    
+
     private var cameraFocusPanGes: UIPanGestureRecognizer?
-    
+
     private var recordLongGes: UILongPressGestureRecognizer?
-    
+
     /// 是否正在调整焦距
     private var isAdjustingFocusPoint = false
-    
+
     /// 是否正在拍照
     private var isTakingPicture = false
-    
+
     private var showFlashBtn = true {
         didSet {
             flashBtn.isHidden = !showFlashBtn
         }
     }
-    
+
     private var shouldUseTapToRecord: Bool {
         cameraConfig.tapToRecordVideo && !cameraConfig.allowTakePhoto
     }
-    
+
     private lazy var cameraConfig = ZLPhotoConfiguration.default().cameraConfiguration
-    
+
+    /// Automatically stops recording video after maxRecordDuration on tapToRecordVideo.
+    private var autoStopTimer: Timer?
+
     // 仅支持竖屏
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         deviceIsiPhone() ? .portrait : .all
     }
-    
+
     override public var prefersStatusBarHidden: Bool {
         return true
     }
-    
+
     deinit {
         zl_debugPrint("ZLCustomCamera deinit")
+        cleanAutoStopTimer()
         cleanTimer()
         try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
-    
+
     @objc public init() {
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
     }
-    
+
     @available(*, unavailable)
     public required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override open func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupUI()
         if !UIImagePickerController.isSourceTypeAvailable(.camera) {
             return
         }
-        
+
         AVCaptureDevice.requestAccess(for: .video) { videoGranted in
             guard videoGranted else {
                 ZLMainAsync(after: 1) {
@@ -284,12 +288,12 @@ open class ZLCustomCamera: UIViewController {
                 }
                 return
             }
-            
+
             guard self.cameraConfig.allowRecordVideo else {
                 self.addNotification()
                 return
             }
-            
+
             AVCaptureDevice.requestAccess(for: .audio) { audioGranted in
                 self.addNotification()
                 if !audioGranted {
@@ -299,7 +303,7 @@ open class ZLCustomCamera: UIViewController {
                 }
             }
         }
-        
+
         if cameraConfig.allowRecordVideo {
             do {
                 try AVAudioSession.sharedInstance().setCategory(.playAndRecord, mode: .videoRecording, options: .duckOthers)
@@ -312,15 +316,15 @@ open class ZLCustomCamera: UIViewController {
                 }
             }
         }
-        
+
         setupCamera()
     }
-    
+
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         observerDeviceMotion()
     }
-    
+
     override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if !UIImagePickerController.isSourceTypeAvailable(.camera) {
@@ -339,70 +343,70 @@ open class ZLCustomCamera: UIViewController {
         }
         viewDidAppearCount += 1
     }
-    
+
     override open func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         motionManager?.stopDeviceMotionUpdates()
         motionManager = nil
     }
-    
+
     override open func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
         guard session.isRunning else { return }
-        
+
         sessionQueue.async {
             self.session.stopRunning()
         }
     }
-    
+
     override open func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         shouldLayout = true
     }
-    
+
     override open func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         guard shouldLayout else { return }
         shouldLayout = false
-        
+
         var insets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         if #available(iOS 11.0, *) {
             insets = self.view.safeAreaInsets
         }
-        
+
         let cameraRatio: CGFloat = 16 / 9
         let layerH = min(view.zl.width * cameraRatio, view.zl.height)
-        
+
         let previewLayerY: CGFloat
         if isSmallScreen() {
             previewLayerY = deviceIsFringeScreen() ? min(94, view.zl.height - layerH) : 0
         } else {
             previewLayerY = 0
         }
-        
+
         let previewFrame = CGRect(x: 0, y: previewLayerY, width: view.bounds.width, height: layerH)
         previewLayer?.frame = previewFrame
         recordVideoPlayerLayer?.frame = previewFrame
         takedImageView.frame = previewFrame
         cameraConfig.overlayView?.frame = previewFrame // Layout custom overlay view.
-        
+
         dismissBtn.frame = CGRect(x: 20, y: 60, width: 30, height: 30)
         retakeBtn.frame = CGRect(x: 20, y: 60, width: 28, height: 28)
-        
+
         var bottomViewToBottomSpacing = view.zl.height - insets.bottom - ZLCustomCamera.Layout.bottomViewH
         if view.zl.height <= 812 {
             bottomViewToBottomSpacing -= deviceIsFringeScreen() ? 40 : 20
         }
-        
+
         bottomView.frame = CGRect(x: 0, y: bottomViewToBottomSpacing, width: view.bounds.width, height: ZLCustomCamera.Layout.bottomViewH)
         let largeCircleH = ZLCustomCamera.Layout.largeCircleRadius
         largeCircleView.frame = CGRect(x: (view.bounds.width - largeCircleH) / 2, y: (ZLCustomCamera.Layout.bottomViewH - largeCircleH) / 2, width: largeCircleH, height: largeCircleH)
         let smallCircleH = ZLCustomCamera.Layout.smallCircleRadius
         smallCircleView.frame = CGRect(x: (view.bounds.width - smallCircleH) / 2, y: (ZLCustomCamera.Layout.bottomViewH - smallCircleH) / 2, width: smallCircleH, height: smallCircleH)
-        
+
         flashBtn.frame = CGRect(x: 60, y: (ZLCustomCamera.Layout.bottomViewH - 25) / 2, width: 25, height: 25)
         switchCameraBtn.frame = CGRect(x: bottomView.zl.width - 60 - 25, y: flashBtn.zl.top, width: 25, height: 25)
-        
+
         let tipsTextHeight = (tipsLabel.text ?? " ").zl
             .boundingRect(
                 font: .zl.font(ofSize: 14),
@@ -410,7 +414,7 @@ open class ZLCustomCamera: UIViewController {
             )
             .height + 30
         tipsLabel.frame = CGRect(x: 10, y: bottomView.frame.minY - tipsTextHeight, width: view.bounds.width - 20, height: tipsTextHeight)
-        
+
         let doneBtnW = (doneBtn.currentTitle ?? "")
             .zl.boundingRect(
                 font: ZLLayout.bottomToolTitleFont,
@@ -420,25 +424,25 @@ open class ZLCustomCamera: UIViewController {
         let doneBtnY = view.bounds.height - 57 - insets.bottom
         doneBtn.frame = CGRect(x: view.bounds.width - doneBtnW - 20, y: doneBtnY, width: doneBtnW, height: ZLLayout.bottomToolBtnH)
     }
-    
+
     private func setupUI() {
         view.backgroundColor = .black
-        
+
         view.addSubview(dismissBtn)
         view.addSubview(takedImageView)
         view.addSubview(focusCursorView)
         view.addSubview(tipsLabel)
         view.addSubview(bottomView)
-        
+
         if let overlayView = cameraConfig.overlayView {
             view.addSubview(overlayView)  // Add custom overlay view.
         }
-        
+
         bottomView.addSubview(flashBtn)
         bottomView.addSubview(largeCircleView)
         bottomView.addSubview(smallCircleView)
         bottomView.addSubview(switchCameraBtn)
-        
+
         var takePictureTap: UITapGestureRecognizer?
         if cameraConfig.allowTakePhoto {
             takePictureTap = UITapGestureRecognizer(target: self, action: #selector(takePicture))
@@ -462,32 +466,32 @@ open class ZLCustomCamera: UIViewController {
                 largeCircleView.addGestureRecognizer(panGes)
                 cameraFocusPanGes = panGes
             }
-            
+
             recordVideoPlayerLayer = AVPlayerLayer()
             recordVideoPlayerLayer?.backgroundColor = UIColor.black.cgColor
             recordVideoPlayerLayer?.videoGravity = .resizeAspect
             recordVideoPlayerLayer?.isHidden = true
             view.layer.insertSublayer(recordVideoPlayerLayer!, at: 0)
-            
+
             NotificationCenter.default.addObserver(self, selector: #selector(recordVideoPlayFinished), name: .AVPlayerItemDidPlayToEndTime, object: nil)
         }
-        
+
         view.addSubview(retakeBtn)
         view.addSubview(doneBtn)
-        
+
         // 预览layer
         previewLayer = AVCaptureVideoPreviewLayer(session: session)
         previewLayer?.videoGravity = .resizeAspectFill
         previewLayer?.opacity = 0
         view.layer.masksToBounds = true
         view.layer.insertSublayer(previewLayer!, at: 0)
-        
+
         view.addGestureRecognizer(focusCursorTapGes)
-        
+
         let pinchGes = UIPinchGestureRecognizer(target: self, action: #selector(pinchToAdjustCameraFocus(_:)))
         view.addGestureRecognizer(pinchGes)
     }
-    
+
     private func observerDeviceMotion() {
         if !Thread.isMainThread {
             ZLMainAsync {
@@ -497,7 +501,7 @@ open class ZLCustomCamera: UIViewController {
         }
         motionManager = CMMotionManager()
         motionManager?.deviceMotionUpdateInterval = 0.5
-        
+
         if motionManager?.isDeviceMotionAvailable == true {
             motionManager?.startDeviceMotionUpdates(to: .main, withHandler: { motion, _ in
                 if let motion = motion {
@@ -508,11 +512,11 @@ open class ZLCustomCamera: UIViewController {
             motionManager = nil
         }
     }
-    
+
     func handleDeviceMotion(_ motion: CMDeviceMotion) {
         let x = motion.gravity.x
         let y = motion.gravity.y
-        
+
         if abs(y) >= abs(x) || abs(x) < 0.45 {
             if y >= 0.45 {
                 orientation = .portraitUpsideDown
@@ -527,32 +531,32 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-    
+
     private func setupCamera() {
         let cameraConfig = ZLPhotoConfiguration.default().cameraConfiguration
-        
+
         guard let camera = getCamera(position: cameraConfig.devicePosition.avDevicePosition) else { return }
         guard let input = try? AVCaptureDeviceInput(device: camera) else { return }
-        
+
         session.beginConfiguration()
-        
+
         // 相机画面输入流
         videoInput = input
-        
+
         refreshSessionPreset(device: camera)
-        
+
         let movieFileOutput = AVCaptureMovieFileOutput()
         // 解决视频录制超过10s没有声音的bug
         movieFileOutput.movieFragmentInterval = .invalid
         self.movieFileOutput = movieFileOutput
-        
+
         // 添加视频输入
         if let videoInput = videoInput, session.canAddInput(videoInput) {
             session.addInput(videoInput)
         }
         // 添加音频输入
         addAudioInput()
-        
+
         // 照片输出流
         let imageOutput = AVCapturePhotoOutput()
         self.imageOutput = imageOutput
@@ -563,18 +567,18 @@ open class ZLCustomCamera: UIViewController {
         if session.canAddOutput(movieFileOutput) {
             session.addOutput(movieFileOutput)
         }
-        
+
         // imageOutPut添加到session之后才能判断supportedFlashModes
         if !cameraConfig.showFlashSwitch || torchDevice?.hasFlash == false {
             ZLMainAsync {
                 self.showFlashBtn = false
             }
         }
-        
+
         session.commitConfiguration()
-        
+
         cameraConfigureFinish = true
-        
+
         sessionQueue.async {
             self.setInitialZoomFactor(for: camera)
             self.session.startRunning()
@@ -591,7 +595,7 @@ open class ZLCustomCamera: UIViewController {
             zl_debugPrint("Failed to set initial zoom factor: \(error.localizedDescription)")
         }
     }
-    
+
     private func findFirstDevice(ofTypes types: [AVCaptureDevice.DeviceType], in session: AVCaptureDevice.DiscoverySession) -> AVCaptureDevice? {
         for type in types {
             if let device = session.devices.first(where: { $0.deviceType == type }) {
@@ -600,16 +604,16 @@ open class ZLCustomCamera: UIViewController {
         }
         return nil
     }
-    
+
     private func refreshSessionPreset(device: AVCaptureDevice) {
         func setSessionPreset(_ preset: AVCaptureSession.Preset) {
             guard session.sessionPreset != preset else {
                 return
             }
-            
+
             session.sessionPreset = preset
         }
-        
+
         let preset = cameraConfig.sessionPreset.avSessionPreset
         if device.supportsSessionPreset(preset), session.canSetSessionPreset(preset) {
             setSessionPreset(preset)
@@ -617,12 +621,12 @@ open class ZLCustomCamera: UIViewController {
             setSessionPreset(.photo)
         }
     }
-    
+
     private func getCamera(position: AVCaptureDevice.Position) -> AVCaptureDevice? {
         let deviceTypes: [AVCaptureDevice.DeviceType] = [.builtInWideAngleCamera]
         var extendedDeviceTypes: [AVCaptureDevice.DeviceType] = []
         let allDeviceTypes: [AVCaptureDevice.DeviceType]
-        
+
         if #available(iOS 13.0, *), cameraConfig.enableWideCameras {
             extendedDeviceTypes = [.builtInTripleCamera, .builtInDualWideCamera, .builtInDualCamera]
             allDeviceTypes = deviceTypes + extendedDeviceTypes
@@ -650,24 +654,24 @@ open class ZLCustomCamera: UIViewController {
         }
         return nil
     }
-    
+
     private func getMicrophone() -> AVCaptureDevice? {
         return AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInMicrophone], mediaType: .audio, position: .unspecified).devices.first
     }
-    
+
     private func addAudioInput() {
         guard cameraConfig.allowRecordVideo else { return }
-        
+
         // 音频输入流
         var audioInput: AVCaptureDeviceInput?
         if let microphone = getMicrophone() {
             audioInput = try? AVCaptureDeviceInput(device: microphone)
         }
-        
+
         guard microPhontIsAvailable, let ai = audioInput else { return }
-        
+
         removeAudioInput()
-        
+
         if session.isRunning {
             session.beginConfiguration()
         }
@@ -678,7 +682,7 @@ open class ZLCustomCamera: UIViewController {
             session.commitConfiguration()
         }
     }
-    
+
     private func removeAudioInput() {
         var audioInput: AVCaptureInput?
         for input in session.inputs {
@@ -687,7 +691,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
         guard let audioInput = audioInput else { return }
-        
+
         if session.isRunning {
             session.beginConfiguration()
         }
@@ -696,16 +700,16 @@ open class ZLCustomCamera: UIViewController {
             session.commitConfiguration()
         }
     }
-    
+
     private func addNotification() {
         NotificationCenter.default.addObserver(self, selector: #selector(appWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
-        
+
         if cameraConfig.allowRecordVideo {
             NotificationCenter.default.addObserver(self, selector: #selector(appDidBecomeActive), name: UIApplication.didBecomeActiveNotification, object: nil)
             NotificationCenter.default.addObserver(self, selector: #selector(handleAudioSessionInterruption), name: AVAudioSession.interruptionNotification, object: nil)
         }
     }
-    
+
     private func showNoMicrophoneAuthorityAlert() {
         let continueAction = ZLCustomAlertAction(title: localLanguageTextValue(.keepRecording), style: .default, handler: nil)
         let gotoSettingsAction = ZLCustomAlertAction(title: localLanguageTextValue(.gotoSettings), style: .tint) { _ in
@@ -718,13 +722,13 @@ open class ZLCustomCamera: UIViewController {
         }
         showAlertController(title: nil, message: String(format: localLanguageTextValue(.noMicrophoneAuthority), getAppName()), style: .alert, actions: [continueAction, gotoSettingsAction], sender: self)
     }
-    
+
     private func showAlertAndDismissAfterDoneAction(message: String, type: ZLNoAuthorityType?) {
         if let type, let customAlertWhenNoAuthority = ZLPhotoConfiguration.default().customAlertWhenNoAuthority {
             customAlertWhenNoAuthority(type)
             return
         }
-        
+
         let action = ZLCustomAlertAction(title: localLanguageTextValue(.done), style: .default) { [weak self] _ in
             self?.dismiss(animated: true) {
                 if let type {
@@ -734,7 +738,7 @@ open class ZLCustomCamera: UIViewController {
         }
         showAlertController(title: nil, message: message, style: .alert, actions: [action], sender: self)
     }
-    
+
     private func cameraUsageTipsText() -> String {
         if cameraConfig.allowTakePhoto, cameraConfig.allowRecordVideo {
             return localLanguageTextValue(.customCameraTips)
@@ -744,13 +748,13 @@ open class ZLCustomCamera: UIViewController {
             if shouldUseTapToRecord {
                 return localLanguageTextValue(.customCameraTapToRecordVideoTips)
             }
-            
+
             return localLanguageTextValue(.customCameraRecordVideoTips)
         } else {
             return ""
         }
     }
-    
+
     private func showTipsLabel(message: String, animated: Bool = true) {
         tipsLabel.layer.removeAllAnimations()
         tipsLabel.text = message
@@ -763,7 +767,7 @@ open class ZLCustomCamera: UIViewController {
         }
         startHideTipsLabelTimer()
     }
-    
+
     private func hideTipsLabel(animated: Bool = true) {
         tipsLabel.layer.removeAllAnimations()
         if animated {
@@ -774,23 +778,28 @@ open class ZLCustomCamera: UIViewController {
             tipsLabel.alpha = 0
         }
     }
-    
+
     @objc private func hideTipsLabel_timerFunc() {
         cleanTimer()
         hideTipsLabel()
     }
-    
+
     private func startHideTipsLabelTimer() {
         cleanTimer()
         hideTipsTimer = Timer.scheduledTimer(timeInterval: 3, target: ZLWeakProxy(target: self), selector: #selector(hideTipsLabel_timerFunc), userInfo: nil, repeats: false)
         RunLoop.current.add(hideTipsTimer!, forMode: .common)
     }
-    
+
     private func cleanTimer() {
         hideTipsTimer?.invalidate()
         hideTipsTimer = nil
     }
-    
+
+    private func cleanAutoStopTimer() {
+        autoStopTimer?.invalidate()
+        autoStopTimer = nil
+    }
+
     @objc private func appWillResignActive() {
         if session.isRunning {
             dismiss(animated: true, completion: nil)
@@ -799,13 +808,13 @@ open class ZLCustomCamera: UIViewController {
             player.pause()
         }
     }
-    
+
     @objc private func appDidBecomeActive() {
         if videoURL != nil, let player = recordVideoPlayerLayer?.player {
             player.play()
         }
     }
-    
+
     @objc private func handleAudioSessionInterruption(_ notify: Notification) {
         guard recordVideoPlayerLayer?.isHidden == false, let player = recordVideoPlayerLayer?.player else {
             return
@@ -813,20 +822,21 @@ open class ZLCustomCamera: UIViewController {
         guard player.rate == 0 else {
             return
         }
-        
+
         let type = notify.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt
         let option = notify.userInfo?[AVAudioSessionInterruptionOptionKey] as? UInt
         if type == AVAudioSession.InterruptionType.ended.rawValue, option == AVAudioSession.InterruptionOptions.shouldResume.rawValue {
             player.play()
         }
     }
-    
+
     @objc private func dismissBtnClick() {
+        cleanAutoStopTimer()
         dismiss(animated: true) {
             self.cancelBlock?()
         }
     }
-    
+
     @objc private func retakeBtnClick() {
         sessionQueue.async {
             self.session.startRunning()
@@ -843,36 +853,36 @@ open class ZLCustomCamera: UIViewController {
             try? FileManager.default.removeItem(at: videoURL)
         }
     }
-    
+
     @objc private func flashBtnClick() {
         flashBtn.isSelected.toggle()
     }
-    
+
     @objc private func switchCameraBtnClick() {
         guard !restartRecordAfterSwitchCamera, !isSwitchingCamera else {
             return
         }
-        
+
         guard let videoInput, let movieFileOutput else {
             return
         }
-        
+
         if movieFileOutput.isRecording {
             let pauseTime = animateLayer.convertTime(CACurrentMediaTime(), from: nil)
             animateLayer.speed = 0
             animateLayer.timeOffset = pauseTime
             restartRecordAfterSwitchCamera = true
         }
-        
+
         isSwitchingCamera = true
         sessionQueue.async {
             do {
                 defer {
                     self.isSwitchingCamera = false
                 }
-                
+
                 let currInput = videoInput
-                
+
                 var newVideoInput: AVCaptureDeviceInput?
                 if currInput.device.position == .back, let front = self.getCamera(position: .front) {
                     newVideoInput = try AVCaptureDeviceInput(device: front)
@@ -881,14 +891,14 @@ open class ZLCustomCamera: UIViewController {
                 } else {
                     return
                 }
-                
+
                 if let newVideoInput {
                     self.session.beginConfiguration()
-                    
+
                     self.refreshSessionPreset(device: newVideoInput.device)
-                    
+
                     self.session.removeInput(currInput)
-                    
+
                     if self.session.canAddInput(newVideoInput) {
                         self.session.addInput(newVideoInput)
                         self.videoInput = newVideoInput
@@ -896,7 +906,7 @@ open class ZLCustomCamera: UIViewController {
                         self.refreshSessionPreset(device: currInput.device)
                         self.session.addInput(currInput)
                     }
-                    
+
                     self.setInitialZoomFactor(for: newVideoInput.device)
                     self.session.commitConfiguration()
                 }
@@ -905,24 +915,24 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-    
+
     private func canEditImage() -> Bool {
         let config = ZLPhotoConfiguration.default()
-        
+
         guard config.allowEditImage else {
             return false
         }
-        
+
         // 如果满足如下条件，则会在拍照完成后，返回相册界面直接进入编辑界面，这里就不在编辑
         let editAfterSelect = config.editAfterSelectThumbnailImage && config.maxSelectCount == 1
         return !editAfterSelect
     }
-    
+
     @objc private func editImage() {
         guard let takedImage = takedImage, canEditImage() else {
             return
         }
-        
+
         ZLEditImageViewController.showEditImageVC(parentVC: self, image: takedImage) { [weak self] in
             self?.retakeBtnClick()
         } completion: { [weak self] editImage, _ in
@@ -931,7 +941,7 @@ open class ZLCustomCamera: UIViewController {
             self?.doneBtnClick()
         }
     }
-    
+
     @objc private func doneBtnClick() {
         recordVideoPlayerLayer?.player?.pause()
         // 置为nil会导致卡顿，先注释，不影响内存释放
@@ -940,7 +950,7 @@ open class ZLCustomCamera: UIViewController {
             self.takeDoneBlock?(self.takedImage, self.videoURL)
         }
     }
-    
+
     // 点击拍照
     @objc private func takePicture() {
         guard ZLPhotoManager.hasCameraAuthority(), !isTakingPicture else {
@@ -953,9 +963,9 @@ open class ZLCustomCamera: UIViewController {
             showAlertAndDismissAfterDoneAction(message: localLanguageTextValue(.cameraUnavailable), type: .camera)
             return
         }
-        
+
         isTakingPicture = true
-        
+
         let connection = imageOutput.connection(with: .video)
         connection?.videoOrientation = cameraConfig.lockedOutputOrientation ?? orientation
         if videoInput?.device.position == .front, connection?.isVideoMirroringSupported == true {
@@ -967,10 +977,10 @@ open class ZLCustomCamera: UIViewController {
         } else {
             setting.flashMode = .off
         }
-        
+
         imageOutput.capturePhoto(with: setting, delegate: self)
     }
-    
+
     // 长按录像
     @objc private func longPressAction(_ longGes: UILongPressGestureRecognizer) {
         if longGes.state == .began {
@@ -982,11 +992,11 @@ open class ZLCustomCamera: UIViewController {
             finishRecord()
         }
     }
-    
+
     @objc private func tapToRecordAction(_ tap: UITapGestureRecognizer) {
         movieFileOutput?.isRecording == true ? finishRecord() : startRecord(shouldScheduleStop: true)
     }
-    
+
     // 调整焦点
     @objc private func adjustFocusPoint(_ tap: UITapGestureRecognizer) {
         guard session.isRunning, !isAdjustingFocusPoint else {
@@ -998,10 +1008,10 @@ open class ZLCustomCamera: UIViewController {
         }
         setFocusCusor(point: point)
     }
-    
+
     private func setFocusCusor(point: CGPoint) {
         animateFocusCursor(point: point)
-        
+
         // UI坐标转换为摄像头坐标
         let cameraPoint = previewLayer?.captureDevicePointConverted(fromLayerPoint: point) ?? view.center
         focusCamera(
@@ -1010,12 +1020,12 @@ open class ZLCustomCamera: UIViewController {
             point: cameraPoint
         )
     }
-    
+
     private func animateFocusCursor(point: CGPoint) {
         isAdjustingFocusPoint = true
         focusCursorView.center = point
         focusCursorView.alpha = 1
-        
+
         let scaleAnimation = ZLAnimationUtils.animation(type: .scale, fromValue: 2, toValue: 1, duration: 0.25)
         let fadeShowAnimation = ZLAnimationUtils.animation(type: .fade, fromValue: 0, toValue: 1, duration: 0.25)
         let fadeDismissAnimation = ZLAnimationUtils.animation(type: .fade, fromValue: 1, toValue: 0, duration: 0.25)
@@ -1028,12 +1038,12 @@ open class ZLCustomCamera: UIViewController {
         group.isRemovedOnCompletion = false
         focusCursorView.layer.add(group, forKey: nil)
     }
-    
+
     // 调整焦距
     @objc private func adjustCameraFocus(_ pan: UIPanGestureRecognizer) {
         let convertRect = bottomView.convert(largeCircleView.frame, to: view)
         let point = pan.location(in: view)
-        
+
         if pan.state == .began {
             dragStart = true
             startRecord()
@@ -1053,19 +1063,19 @@ open class ZLCustomCamera: UIViewController {
             finishRecord()
         }
     }
-    
+
     @objc private func pinchToAdjustCameraFocus(_ pinch: UIPinchGestureRecognizer) {
         guard let device = videoInput?.device else {
             return
         }
-        
+
         var zoomFactor = device.videoZoomFactor * pinch.scale
         zoomFactor = max(1, min(zoomFactor, getMaxZoomFactor()))
         setVideoZoomFactor(zoomFactor)
-        
+
         pinch.scale = 1
     }
-    
+
     private func isWideCameraEnabled() -> Bool {
         if #available(iOS 13.0, *) {
             return cameraConfig.enableWideCameras
@@ -1073,7 +1083,7 @@ open class ZLCustomCamera: UIViewController {
             return false
         }
     }
-    
+
     private func getMaxZoomFactor() -> CGFloat {
         guard let device = videoInput?.device else {
             return 1
@@ -1085,7 +1095,7 @@ open class ZLCustomCamera: UIViewController {
             return min(15, device.activeFormat.videoMaxZoomFactor)
         }
     }
-    
+
     private func setVideoZoomFactor(_ zoomFactor: CGFloat) {
         guard let device = videoInput?.device else {
             return
@@ -1104,15 +1114,15 @@ open class ZLCustomCamera: UIViewController {
             zl_debugPrint("调整焦距失败 \(error.localizedDescription)")
         }
     }
-    
+
     private func focusCamera(mode: AVCaptureDevice.FocusMode, exposureMode: AVCaptureDevice.ExposureMode, point: CGPoint) {
         do {
             guard let device = videoInput?.device else {
                 return
             }
-            
+
             try device.lockForConfiguration()
-            
+
             if device.isFocusModeSupported(mode) {
                 device.focusMode = mode
             }
@@ -1125,13 +1135,13 @@ open class ZLCustomCamera: UIViewController {
             if device.isExposurePointOfInterestSupported {
                 device.exposurePointOfInterest = point
             }
-            
+
             device.unlockForConfiguration()
         } catch {
             zl_debugPrint("相机聚焦设置失败 \(error.localizedDescription)")
         }
     }
-    
+
     // 打开手电筒
     private func openTorch() {
         guard flashBtn.isSelected,
@@ -1139,7 +1149,7 @@ open class ZLCustomCamera: UIViewController {
               torchDevice?.torchMode == .off else {
             return
         }
-        
+
         sessionQueue.async {
             do {
                 try self.torchDevice?.lockForConfiguration()
@@ -1150,7 +1160,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-    
+
     // 关闭手电筒
     private func closeTorch() {
         guard flashBtn.isSelected,
@@ -1158,7 +1168,7 @@ open class ZLCustomCamera: UIViewController {
               torchDevice?.torchMode == .on else {
             return
         }
-        
+
         sessionQueue.async {
             do {
                 try self.torchDevice?.lockForConfiguration()
@@ -1169,24 +1179,24 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-    
+
     private func startRecord(shouldScheduleStop: Bool = false) {
         guard let movieFileOutput = movieFileOutput else {
             return
         }
-        
+
         guard !movieFileOutput.isRecording else {
             return
         }
-        
+
         guard session.outputs.contains(movieFileOutput) else {
             showAlertAndDismissAfterDoneAction(message: localLanguageTextValue(.cameraUnavailable), type: .camera)
             return
         }
-        
+
         dismissBtn.isHidden = true
         flashBtn.isHidden = true
-        
+
         let connection = movieFileOutput.connection(with: .video)
         connection?.videoScaleAndCropFactor = 1
         if !restartRecordAfterSwitchCamera {
@@ -1196,11 +1206,11 @@ open class ZLCustomCamera: UIViewController {
         } else {
             connection?.videoOrientation = cacheVideoOrientation
         }
-            
+
         if let connection = connection, connection.isVideoStabilizationSupported {
             connection.preferredVideoStabilizationMode = cameraConfig.videoStabilizationMode
         }
-        
+
         // 解决不同系统版本,因为录制视频编码导致安卓端无法播放的问题
         if #available(iOS 11.0, *),
            movieFileOutput.availableVideoCodecTypes.contains(cameraConfig.videoCodecType),
@@ -1218,23 +1228,27 @@ open class ZLCustomCamera: UIViewController {
         } else {
             openTorch()
         }
-        
+
         let url = URL(fileURLWithPath: ZLVideoManager.getVideoExportFilePath())
         movieFileOutput.startRecording(to: url, recordingDelegate: self)
-        
-        if shouldScheduleStop { // Schedule stop recording after max duration
-            ZLMainAsync(after: Double(cameraConfig.maxRecordDuration)) {
-                if self.movieFileOutput?.isRecording == true {
-                    self.finishRecord()
+
+        if shouldScheduleStop {
+            cleanAutoStopTimer() // Cancel any existing timer.
+            autoStopTimer = Timer.scheduledTimer(
+                withTimeInterval: Double(cameraConfig.maxRecordDuration),
+                repeats: false
+            ) { [weak self] _ in // Schedule new timer for full duration.
+                if self?.movieFileOutput?.isRecording == true {
+                    self?.finishRecord()
                 }
             }
         }
     }
-    
+
     private func finishRecord() {
         closeTorch()
         restartRecordAfterSwitchCamera = false
-        
+
         guard let movieFileOutput = movieFileOutput else {
             return
         }
@@ -1242,10 +1256,10 @@ open class ZLCustomCamera: UIViewController {
         guard movieFileOutput.isRecording else {
             return
         }
-        
+
         movieFileOutput.stopRecording()
     }
-    
+
     private func startRecordAnimation() {
         UIView.animate(withDuration: 0.1, animations: {
             self.largeCircleView.layer.transform = CATransform3DScale(CATransform3DIdentity, ZLCustomCamera.Layout.largeCircleRecordScale, ZLCustomCamera.Layout.largeCircleRecordScale, 1)
@@ -1265,7 +1279,7 @@ open class ZLCustomCamera: UIViewController {
             self.animateLayer.add(animation, forKey: nil)
         }
     }
-    
+
     private func stopRecordAnimation() {
         ZLMainAsync {
             self.smallCircleView.backgroundColor = ZLCustomCamera.Layout.cameraBtnNormalColor
@@ -1280,7 +1294,7 @@ open class ZLCustomCamera: UIViewController {
             self.smallCircleView.transform = .identity
         }
     }
-    
+
     private func resetSubViewStatus() {
         ZLMainAsync {
             if self.session.isRunning {
@@ -1307,7 +1321,7 @@ open class ZLCustomCamera: UIViewController {
             }
         }
     }
-    
+
     private func playRecordVideo(fileURL: URL) {
         recordVideoPlayerLayer?.isHidden = false
         cameraConfig.overlayView?.isHidden = true
@@ -1316,7 +1330,7 @@ open class ZLCustomCamera: UIViewController {
         recordVideoPlayerLayer?.player = player
         player.play()
     }
-    
+
     @objc private func recordVideoPlayFinished() {
         recordVideoPlayerLayer?.player?.seek(to: .zero)
         recordVideoPlayerLayer?.player?.play()
@@ -1330,19 +1344,19 @@ extension ZLCustomCamera: AVCapturePhotoCaptureDelegate {
             self.previewLayer?.add(animation, forKey: nil)
         }
     }
-    
+
     public func photoOutput(_ output: AVCapturePhotoOutput, didFinishProcessingPhoto photoSampleBuffer: CMSampleBuffer?, previewPhoto previewPhotoSampleBuffer: CMSampleBuffer?, resolvedSettings: AVCaptureResolvedPhotoSettings, bracketSettings: AVCaptureBracketedStillImageSettings?, error: Error?) {
         cameraConfig.overlayView?.isHidden = true
         ZLMainAsync {
             defer {
                 self.isTakingPicture = false
             }
-            
+
             if photoSampleBuffer == nil || error != nil {
                 zl_debugPrint("拍照失败 \(error?.localizedDescription ?? "")")
                 return
             }
-            
+
             if let data = AVCapturePhotoOutput.jpegPhotoDataRepresentation(forJPEGSampleBuffer: photoSampleBuffer!, previewPhotoSampleBuffer: previewPhotoSampleBuffer) {
                 self.sessionQueue.async {
                     self.session.stopRunning()
@@ -1369,7 +1383,7 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
             finishRecord()
             return
         }
-        
+
         if restartRecordAfterSwitchCamera {
             restartRecordAfterSwitchCamera = false
             ZLMainAsync {
@@ -1386,35 +1400,36 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
             }
         }
     }
-    
+
     public func fileOutput(_ output: AVCaptureFileOutput, didFinishRecordingTo outputFileURL: URL, from connections: [AVCaptureConnection], error: Error?) {
         ZLMainAsync {
             self.recordURLs.append(outputFileURL)
             self.recordDurations.append(output.recordedDuration.seconds)
-            
+
             if self.restartRecordAfterSwitchCamera {
                 self.startRecord()
                 return
             }
-            
+
             self.finishRecordAndMergeVideo()
         }
     }
-    
+
     private func finishRecordAndMergeVideo() {
         ZLMainAsync {
             self.stopRecordAnimation()
-            
+            self.cleanAutoStopTimer() // Cancel timer when recording finishes.
+
             defer {
                 self.resetSubViewStatus()
             }
-            
+
             guard !self.recordURLs.isEmpty else {
                 return
             }
-            
+
             let duration = self.recordDurations.reduce(0, +)
-            
+
             // 重置焦距
             self.setVideoZoomFactor(1)
             if duration < Double(self.cameraConfig.minRecordDuration) {
@@ -1424,15 +1439,15 @@ extension ZLCustomCamera: AVCaptureFileOutputRecordingDelegate {
                 self.recordDurations.removeAll()
                 return
             }
-            
+
             self.session.stopRunning()
-            
+
             // 拼接视频
             if self.recordURLs.count > 1 {
                 let hud = ZLProgressHUD.show(toast: .processing)
                 ZLVideoManager.mergeVideos(fileURLs: self.recordURLs) { [weak self] url, error in
                     hud.hide()
-                    
+
                     if let url = url, error == nil {
                         self?.videoURL = url
                         self?.playRecordVideo(fileURL: url)
@@ -1471,12 +1486,12 @@ extension ZLCustomCamera: CAAnimationDelegate {
 extension ZLCustomCamera: UIGestureRecognizerDelegate {
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         let gesTuples: [(UIGestureRecognizer?, UIGestureRecognizer?)] = [(recordLongGes, cameraFocusPanGes), (recordLongGes, focusCursorTapGes), (cameraFocusPanGes, focusCursorTapGes)]
-        
+
         let result = gesTuples.map { ges1, ges2 in
             (ges1 == gestureRecognizer && ges2 == otherGestureRecognizer) ||
                 (ges2 == otherGestureRecognizer && ges1 == gestureRecognizer)
         }.filter { $0 == true }
-        
+
         return !result.isEmpty
     }
 }

--- a/Sources/General/ZLCameraConfiguration.swift
+++ b/Sources/General/ZLCameraConfiguration.swift
@@ -138,6 +138,9 @@ public class ZLCameraConfiguration: NSObject {
             pri_videoCodecType = newValue
         }
     }
+    
+    /// Optional lock for output orientation. If set, any video/photo output will use this orientation.
+    public var lockedOutputOrientation: AVCaptureVideoOrientation? = nil
 }
 
 public extension ZLCameraConfiguration {
@@ -342,6 +345,12 @@ public extension ZLCameraConfiguration {
     @discardableResult
     func videoStabilizationMode(_ value: AVCaptureVideoStabilizationMode) -> ZLCameraConfiguration {
         videoStabilizationMode = value
+        return self
+    }
+    
+    @discardableResult
+    func lockedOutputOrientation(_ orientation: AVCaptureVideoOrientation?) -> ZLCameraConfiguration {
+        self.lockedOutputOrientation = orientation
         return self
     }
 }


### PR DESCRIPTION
Hey @longitachi

It's me again :D, in this PR I have made 3 changes:
1. Added a new optional `lockedOutputOrientation` param - this allows users to record videos and take photos in locked orientation (so users can rotate the device anyhow, but the output will always be in this orientation (if provided).
2. Added `autoStopTimer` to more stable video stopping, because the old one had a bug -  since it's possible to provide `maxRecordDuration` and `minRecordDuration`, and if both are provided (let's say 15 seconds min, 30 seconds max) together with `tapToRecordVideo` set to `true`, and then when the user started recording video with a tap, but stopped it after 13s - he will see the dialog that minimum length is 15s (so far everything is correct), he taps record button again - but instead of recording and finish automatically after 30 seconds - it finishes after 17sec automatically (because of 30-13).
3. Fix for zoom factor reset when wide lens cameras are enabled in [this](https://github.com/longitachi/ZLPhotoBrowser/commit/f784bde0b119b445cf2df5bf956f74952aa1c60c) one line.

Thanks!