### PR TITLE
feat: willCaptureBlock callback for custom actions before capture

### DIFF
--- a/Sources/Camera/ZLCustomCamera.swift
+++ b/Sources/Camera/ZLCustomCamera.swift
@@ -45,6 +45,8 @@ open class ZLCustomCamera: UIViewController {
     
     @objc public var cancelBlock: (() -> Void)?
     
+    @objc public var willCaptureBlock: ((@escaping () -> Void) -> Void)?
+    
     public lazy var tipsLabel: UILabel = {
         let label = UILabel()
         label.font = .zl.font(ofSize: 14)
@@ -951,6 +953,16 @@ open class ZLCustomCamera: UIViewController {
     
     // 点击拍照
     @objc private func takePicture() {
+        if let willCaptureBlock = willCaptureBlock {
+            willCaptureBlock { [weak self] in
+                self?.performPhotoCapture()
+            }
+        } else {
+            performPhotoCapture()
+        }
+    }
+
+    private func performPhotoCapture() {
         guard ZLPhotoManager.hasCameraAuthority(), !isTakingPicture else {
             return
         }
@@ -1179,6 +1191,16 @@ open class ZLCustomCamera: UIViewController {
     }
     
     private func startRecord(shouldScheduleStop: Bool = false) {
+        if let willCaptureBlock = willCaptureBlock {
+            willCaptureBlock { [weak self] in
+                self?.startRecording(shouldScheduleStop: shouldScheduleStop)
+            }
+        } else {
+            startRecording(shouldScheduleStop: shouldScheduleStop)
+        }
+    }
+
+    private func startRecording(shouldScheduleStop: Bool = false) {
         guard let movieFileOutput = movieFileOutput else {
             return
         }
@@ -1205,7 +1227,7 @@ open class ZLCustomCamera: UIViewController {
             connection?.videoOrientation = cacheVideoOrientation
         }
         
-        if let connection = connection, connection.isVideoStabilizationSupported {
+        if let connection = connection, connection.isVideoStabilizationSupported, videoInput?.device.position == .back {
             connection.preferredVideoStabilizationMode = cameraConfig.videoStabilizationMode
         }
         


### PR DESCRIPTION
Hey @longitachi!

This PR introduces a new `willCaptureBlock` property to `ZLCustomCamera` that provides a hook for executing custom actions right before capturing photos or recording videos. Additionally it applies video stabilization on back cameras only, since this is not generally supported in from iPhone cameras.

### Features
- Execute custom code before camera capture occurs.
- Support for continuation via a completion handler.
- Works with both photo and video capture modes.

### Use Cases
- Add custom shutter sounds.
- Implement countdown timers before capture.
- Show flash animations or visual indicators.
- Run haptic feedback before capturing.
- Display custom time-related overlays or instructions.

### Implementation
The `willCaptureBlock` is implemented as:
```swift
@objc public var willCaptureBlock: ((@escaping () -> Void) -> Void)?
```

This allows developers to perform async operations and control when to actually proceed with the capture by calling the completion handler.

### Example Usage
```swift
let camera = ZLCustomCamera()
camera.willCaptureBlock = { completion in
    // Play shutter sound
    AudioServicesPlaySystemSound(1108)
    
    // Optional: Show countdown
    let countdownView = CountdownView(frame: view.bounds)
    view.addSubview(countdownView)
    countdownView.start(duration: 3) {
        countdownView.removeFromSuperview()
        // Continue with capture after countdown
        completion()
    }
    
    // If no countdown, call completion() immediately
    // completion()
}
```

This enhancement adds significant flexibility to the camera interface while maintaining the existing core functionality.