### PR TITLE
Update ZLImagePreviewController

### DIFF
--- a/Sources/General/ZLImagePreviewController.swift
+++ b/Sources/General/ZLImagePreviewController.swift
@@ -168,7 +168,7 @@ public class ZLImagePreviewController: UIViewController {
     @objc public var longPressBlock: ((_ vc: ZLImagePreviewController?, _ index: Int) -> Void)?
     
     @objc public var doneBlock: (([Any]) -> Void)?
-    @objc public var disappearBlock: (() -> Void)?
+    @objc public var didDisappearBlock: (() -> Void)?
     
     @objc public var videoHttpHeader: [String: Any]?
     
@@ -250,7 +250,7 @@ public class ZLImagePreviewController: UIViewController {
     
     override public func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        disappearBlock?()
+        didDisappearBlock?()
     }
     
     override public func viewDidLayoutSubviews() {


### PR DESCRIPTION
#selectStatus更新为外部可访问 doneBlock返回的datas不好根据下标索引 针对复杂datas判断比较麻烦 

#新增一个disappearBlock 在使用await withxxxContinuation { continuation in ...}的时候 方便continuation.resume()
替换原来的本地实现
<img width="737" height="260" alt="image" src="https://github.com/user-attachments/assets/8ea860c5-9e29-4512-9189-8773693b5daa" />
