### PR TITLE
Fix out-of-bounds crash during photo preloading

### DIFF
--- a/Sources/General/ZLAlbumListModel.swift
+++ b/Sources/General/ZLAlbumListModel.swift
@@ -97,28 +97,33 @@ public class ZLAlbumListModel: NSObject {
     
     @discardableResult
     public func preloadPhotos(loadAll: Bool = false) -> [ZLPhotoModel] {
+        let snapshot = result
+
         // 受限访问时，如果首次未选择任何照片，currentLoadIndex会为0，那么后续再添加照片的时候，需要重置该值来触发重新加载
         // bug: https://github.com/longitachi/ZLPhotoBrowser/issues/1016
-        if currentLoadIndex == 0, models.count != result.count {
-            currentLoadIndex = result.count
+        if currentLoadIndex == 0, models.count != snapshot.count {
+            currentLoadIndex = snapshot.count
             models.removeAll()
         }
         
         guard currentLoadIndex > 0 else { return [] }
+
+        let loadEndIndex = min(currentLoadIndex, snapshot.count)
+        guard loadEndIndex > 0 else { return [] }
         
         var loadCount = onceLoadCount
-        let isFirstLoad = currentLoadIndex == result.count
+        let isFirstLoad = loadEndIndex == snapshot.count
         if isFirstLoad {
             // mod横竖屏列数的最小公倍数，并在第一次加载时候把余数给加载了，从而使后续分页加载的数据均为整数行
-            let mod = result.count % lcmColumns
+            let mod = snapshot.count % lcmColumns
             loadCount = onceLoadCount + mod
         }
         
-        let minIndex = loadAll ? 0 : max(0, currentLoadIndex - loadCount)
-        let indexSet = IndexSet(minIndex..<currentLoadIndex)
+        let minIndex = loadAll ? 0 : max(0, loadEndIndex - loadCount)
+        let indexSet = IndexSet(minIndex..<loadEndIndex)
         currentLoadIndex = minIndex
         let models = ZLPhotoManager.fetchPhoto(
-            in: result,
+            in: snapshot,
             ascending: ZLPhotoUIConfiguration.default().sortAscending,
             allowSelectImage: ZLPhotoConfiguration.default().allowSelectImage,
             allowSelectVideo: ZLPhotoConfiguration.default().allowSelectVideo,


### PR DESCRIPTION
## 问题描述

收到一例缩略图后台预加载崩溃。Sentry breadcrumbs 显示崩溃前系统 `PHPickerViewController` 正在展示，崩溃堆栈指向 `ZLAlbumListModel.preloadPhotos()`。

```text
*** -[NSArray enumerateObjectsAtIndexes:options:usingBlock:]: index 19 beyond bounds [0 .. 0]
```

崩溃时 `IndexSet` 包含 index 19，但被枚举的 `PHFetchResult` 只有一个对象。

```text
OS Version: iOS 26.6 (23G71)
Report Version: 104

Exception Type: EXC_CRASH (SIGABRT)
Crashed Thread: 99

Application Specific Information:
*** -[NSArray enumerateObjectsAtIndexes:options:usingBlock:]: index 19 beyond bounds [0 .. 0]

Thread 99 Crashed:
0   CoreFoundation                  0x32099b244         <redacted>
1   libobjc.A.dylib                 0x31a019224         objc_exception_throw
2   CoreFoundation                  0x3208b5c90         <redacted>
3   CoreFoundation                  0x320975514         <redacted>
4   Photos                          0x3557b36e0         <redacted>
5   App                             0x207328a64         [inlined] ZLPhotoManager.fetchPhoto
6   App                             0x207328a64         ZLAlbumListModel.preloadPhotos (ZLAlbumListModel.swift:120)
7   App                             0x2073e3470         closure in ZLThumbnailViewController.loadPhotos (ZLThumbnailViewController.swift:573)
8   App                             0x204dc35f0         thunk for closure
9   libdispatch.dylib               0x395f019a8         <redacted>
10  libdispatch.dylib               0x395f1b1e4         <redacted>
11  libdispatch.dylib               0x395f37a64         <redacted>
12  libdispatch.dylib               0x395f05de0         <redacted>
13  libdispatch.dylib               0x395f13900         <redacted>
14  libdispatch.dylib               0x395f14098         <redacted>
15  libsystem_pthread.dylib         0x3dfc05374         _pthread_wqthread
16  libsystem_pthread.dylib         0x3dfc048c0         start_wqthread
```

## 原因分析

`preloadPhotos()` 使用 `currentLoadIndex` 计算 `IndexSet`，但没有保证该值小于当前 `result.count`。

同时，一次预加载过程中会多次读取 `result`。`result` 被更新后，分页索引可能仍然来自之前的状态，导致计算出的 `IndexSet` 超出实际 fetch result 的范围。

## 修复方案

在 `preloadPhotos()` 中固定使用同一个 `result` 快照，并将加载索引限制在 `snapshot.count` 范围内，避免枚举时发生越界。
